### PR TITLE
add cmake logic to perform std::to_string patches as needed 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,21 @@ if(ACF_BUILD_TESTS)
 
 endif()
 
+if(ACF_SERIALIZE_WITH_CEREAL)
+  #### std::to_string ####
+  try_compile(ACF_HAVE_TO_STRING "${CMAKE_BINARY_DIR}/compile_tests" "${PROJECT_SOURCE_DIR}/cmake/to_string.cpp")
+  if(ACF_HAVE_TO_STRING)
+    set(ACF_ADD_TO_STRING OFF)
+  else()
+    set(ACF_ADD_TO_STRING ON)
+  endif()
+else(ACF_USE_CEREAL)
+  # This is never needed when CEREAL extensions are disabled
+  set(ACF_ADD_TO_STRING OFF)
+endif(ACF_SERIALIZE_WITH_CEREAL)
+
+message("ACF_ADD_TO_STRING : ${ACF_ADD_TO_STRING}")
+
 ##############
 ## Project ###
 ##############

--- a/bin/build-xcode.sh
+++ b/bin/build-xcode.sh
@@ -5,11 +5,10 @@ CONFIG=MinSizeRel
 
 ARGS=(
     --verbose
+    --toolchain ${TOOLCHAIN}
     --config ${CONFIG}
     --fwd HUNTER_CONFIGURATION_TYPES=${CONFIG}
     --jobs 8
 )
 
-build.py --toolchain ${TOOLCHAIN} ${ARGS[@]} --install ${*}
-
-
+build.py ${ARGS[@]} --install ${*}

--- a/cmake/to_string.cpp
+++ b/cmake/to_string.cpp
@@ -1,0 +1,5 @@
+#include <string>
+int main(int argc, char *argv[])
+{
+    auto str = std::to_string(1);
+}

--- a/src/app/acf/acf.cpp
+++ b/src/app/acf/acf.cpp
@@ -9,7 +9,12 @@
 */
 
 // Local includes:
-#include "io/stdlib_string.h" // android workaround
+
+// clang-format off
+#if defined(ACF_ADD_TO_STRING)
+#  include "io/stdlib_string.h" // android workaround
+#endif
+// clang-format on
 
 #include "acf/ACF.h"
 

--- a/src/app/acf/mat2cpb.cpp
+++ b/src/app/acf/mat2cpb.cpp
@@ -8,7 +8,11 @@
  
  */
 
-#include "io/stdlib_string.h"
+// clang-format off
+#if defined(ACF_ADD_TO_STRING)
+#  include "io/stdlib_string.h"
+#endif
+// clang-format on
 #include "io/cereal_pba.h"
 #include "util/Logger.h"
 #include "util/string_hash.h"

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -18,7 +18,9 @@ target_compile_definitions(acf PUBLIC _USE_MATH_DEFINES)  # define M_PI_2 for Vi
 if(ACF_SERIALIZE_WITH_CVMATIO)
   target_compile_definitions(acf PUBLIC ACF_SERIALIZE_WITH_CVMATIO=1)
 endif()
-
+if(ACF_ADD_TO_STRING)
+  target_compile_definitions(acf PUBLIC ACF_ADD_TO_STRING=1)
+endif()
 target_include_directories(acf
   PUBLIC
   "$<BUILD_INTERFACE:${ACF_ROOT_DIR}/src/lib/>"

--- a/src/lib/acf/ACFIO.cpp
+++ b/src/lib/acf/ACFIO.cpp
@@ -182,7 +182,11 @@ int Detector::deserialize(ParserNodeDetector& detector_) { return -1; }
 
 ACF_NAMESPACE_END
 
-#include "io/stdlib_string.h"
+// clang-format off
+#if defined(ACF_ADD_TO_STRING)
+#  include "io/stdlib_string.h"
+#endif
+// clang-format on
 #include "io/cereal_pba.h"
 
 ACF_NAMESPACE_BEGIN

--- a/src/lib/acf/ACFIOArchiveCereal.cpp
+++ b/src/lib/acf/ACFIOArchiveCereal.cpp
@@ -1,4 +1,8 @@
-#include "io/stdlib_string.h"
+// clang-format off
+#if defined(ACF_ADD_TO_STRING)
+#  include "io/stdlib_string.h"
+#endif
+// clang-format on
 #include "io/cereal_pba.h"
 #include "io/cvmat_cereal.h"
 #include "acf/ACFIOArchive.h"

--- a/src/lib/acf/ut/test-acf.cpp
+++ b/src/lib/acf/ut/test-acf.cpp
@@ -41,7 +41,11 @@ int gauze_main(int argc, char** argv)
 #endif
 // clang-format on
 
-#include "io/stdlib_string.h"
+// clang-format off
+#if defined(ACF_ADD_TO_STRING)
+#  include "io/stdlib_string.h"
+#endif
+// clang-format on
 #include "io/cereal_pba.h"
 
 // http://uscilab.github.io/cereal/serialization_archives.html

--- a/src/lib/io/stdlib_string.h
+++ b/src/lib/io/stdlib_string.h
@@ -11,8 +11,6 @@
 #ifndef __io_stdlib_string_h__
 #define __io_stdlib_string_h__
 
-#if ANDROID
-
 #include "acf/acf_common.h"
 
 #include <string>
@@ -95,8 +93,5 @@ inline float strtof(const char* str, char** str_end)
 }
 
 ACF_END_NAMESPACE(std)
-
-#include <cerrno>
-#endif
 
 #endif // __io_stdlib_string_h__

--- a/src/lib/io/sugar.cmake
+++ b/src/lib/io/sugar.cmake
@@ -10,5 +10,8 @@ sugar_files(ACF_HDRS
   cereal_pba.h
   cv_cereal.h
   cvmat_cereal.h
-  stdlib_string.h
   )
+
+if(ACF_ADD_TO_STRING)
+  sugar_files(ACF_HDRS stdlib_string.h)
+endif()


### PR DESCRIPTION
... primarily for android

* cmake logic for std::to_string related augmentation
  + cmake/to_string.cpp w/ try_compile
  + target_compile_definitions(acf PUBLIC …)
* remove an unused cmakelists.txt