### PR TITLE
ACF processing fixes and test features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,34 @@
 
 cmake_minimum_required(VERSION 3.3)
 
+# By default, the source code for all managed dependencies will be removed after
+# building and installing to the cache.  This behavior is consistent with most 
+# installed libraries (i.e., /usr/local/lib/*), but it does prevent stepping 
+# through the dependencies in a debugger in cases where a problem is not 
+# contained within the acf project sources.  In such cases, you can set 
+# HUNTER_KEEP_PACKAGE_SOURCES=ON from the command line during the project 
+# configuration and the source will be left for all packages when they are
+# created.  This setting must be used before a package is installed -- it 
+# won't be applied retroactively to installed packages.  In order to re-install
+# a package with sources you can always remove the cache
+# (i.e., rm -rf ${HOME}/.hunter) or, less drastically you can modify the 
+# CONFIG-ID of an installed package to trigger the configuration and 
+# installation steps.  This can be done by modifying the input CMAKE_ARGS 
+# list in a hunter_config() call.  In the following example KEEP_SOURCES=1
+# is  added to trigger a re-installation:
+#
+#   hunter_config(foo VERSION ${HUNTER_foo_VERSION} CMAKE_ARGS KEEP_SOURCES=1)
+#
+# The HUNTER_KEEP_PACKAGE_SOURCES development feature is described here:
+#
+# In order to support stepping through package sources you will also have to
+# make sure that debug versions of the packages are installed.  This will
+# happen by default, but will not happen if you specify a release only build
+# using HUNTER_CONFIGURATION_TYPES=Release
+
+# https://docs.hunter.sh/en/latest/reference/user-variables.html#hunter-keep-package-sources
+option(HUNTER_KEEP_PACKAGE_SOURCES "Keep installed package sources for debugging (caveat...)" OFF)
+
 #########################
 ### CMAKE_MODULE_PATH ###
 #########################
@@ -59,7 +87,7 @@ else()
       # ******************
       # *** FUTURE USE ***
       # ******************
-      #FILEPATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/config.cmake"
+      FILEPATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/config.cmake"
     )
   endif()
 endif()
@@ -227,6 +255,14 @@ if(ACF_BUILD_TESTS)
     LOCATION ACF_PEDESTRIAN_IMAGE
   )
   message("ACF_PEDESTRIAN_IMAGE = ${ACF_PEDESTRIAN_IMAGE}")
+
+  hunter_private_data(
+    URL "${acf_release_url}/dodecagon.png"
+    SHA1 "1b5149cdf40611426de1e1951fb3d9c947b9f080"
+    FILE "dodecagon.png"
+    LOCATION ACF_DODECAGON_IMAGE
+  )
+  message("ACF_DODECAGON_IMAGE = ${ACF_DODECAGON_IMAGE}")
 
 endif()
 

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,0 +1,10 @@
+string(COMPARE EQUAL "${CMAKE_OSX_SYSROOT}" "iphoneos" _is_ios)
+if(_is_ios)
+  set(opencv_cmake_args
+    WITH_PROTOBUF=OFF
+    BUILD_PROTOBUF=OFF
+    BUILD_LIBPROTOBUF_FROM_SOURCES=NO
+    BUILD_opencv_dnn=OFF
+    )
+  hunter_config(OpenCV VERSION ${HUNTER_OpenCV_VERSION} CMAKE_ARGS ${opencv_cmake_args})
+endif()

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,5 +1,6 @@
-string(COMPARE EQUAL "${CMAKE_OSX_SYSROOT}" "iphoneos" _is_ios)
-if(_is_ios)
+if(IOS)
+  # local workaround for protobuf compiler crash with Xcode 8.1
+  # see https://github.com/elucideye/acf/issues/41
   set(opencv_cmake_args
     WITH_PROTOBUF=OFF
     BUILD_PROTOBUF=OFF

--- a/src/app/acf/CMakeLists.txt
+++ b/src/app/acf/CMakeLists.txt
@@ -28,6 +28,24 @@ endif()
 set_property(TARGET ${test_app} PROPERTY FOLDER "app/console")
 install(TARGETS ${test_app} DESTINATION bin)
 
+set_target_properties(
+  ${test_app}
+  PROPERTIES
+  MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_LIST_DIR}/plist.in" # file sharing
+  XCODE_ATTRIBUTE_PRODUCT_NAME "${test_app}"
+  XCODE_ATTRIBUTE_BUNDLE_IDENTIFIER "com.elucideye.acf.${test_app}"
+  XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.elucideye.acf.${test_app}"
+  XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2" # iPhone/iPad
+)
+
+# gauze_add_test(
+#   NAME AcfDetect
+#   COMMAND ${test_app}
+#   "IOS_TEST"
+#   "$<GAUZE_RESOURCE_FILE:${DRISHTI_ASSETS_FACE_DETECTOR}>"
+#   "$<GAUZE_RESOURCE_FILE:${ACF_DODECAGON_IMAGE}>"
+# )
+
 ###############
 ### mat2cpb ###
 ###############

--- a/src/app/acf/GLDetector.cpp
+++ b/src/app/acf/GLDetector.cpp
@@ -20,7 +20,7 @@ static void* void_ptr(const unsigned char* ptr);
 static std::vector<ogles_gpgpu::Size2d> getPyramidSizes(acf::Detector::Pyramid& Pcpu, int shrink);
 static cv::Mat cvtAnyTo8UC4(const cv::Mat& input);
 
-static cv::Mat draw(const acf::Detector::Pyramid& pyramid);
+static cv::Mat drawPyramid(const acf::Detector::Pyramid& pyramid);
 static void logPyramid(const std::string& filename, const acf::Detector::Pyramid& P);
 
 struct GLDetector::Impl
@@ -128,6 +128,21 @@ std::vector<ogles_gpgpu::Size2d> getPyramidSizes(acf::Detector::Pyramid& Pcpu, i
     return sizes;
 }
 
+void GLDetector::clear()
+{
+    m_impl->size = {0,0};
+}
+
+cv::Mat GLDetector::draw(bool doGpu)
+{
+    cv::Mat pyramid = drawPyramid(doGpu ? m_impl->Pgpu : m_impl->Pcpu);
+    if (pyramid.depth() != CV_8UC1)
+    {
+        pyramid.convertTo(pyramid, CV_8UC1, 255.0);
+    }
+    return pyramid;
+}
+
 static cv::Mat cvtAnyTo8UC4(const cv::Mat& input)
 {
     cv::Mat output;
@@ -160,7 +175,7 @@ static cv::Mat cvtAnyTo8UC4(const cv::Mat& input)
     return output;
 }
 
-static cv::Mat draw(const acf::Detector::Pyramid& pyramid)
+static cv::Mat drawPyramid(const acf::Detector::Pyramid& pyramid)
 {
     cv::Mat canvas;
     std::vector<cv::Mat> levels;
@@ -191,7 +206,7 @@ static cv::Mat draw(const acf::Detector::Pyramid& pyramid)
 
 static void logPyramid(const std::string& filename, const acf::Detector::Pyramid& P)
 {
-    cv::Mat canvas = draw(P);
+    cv::Mat canvas = drawPyramid(P);
 
     if (canvas.depth() != CV_8UC1)
     {

--- a/src/app/acf/GLDetector.h
+++ b/src/app/acf/GLDetector.h
@@ -35,6 +35,9 @@ public:
     // Virtual API:
     virtual int operator()(const cv::Mat& input, RectVec& objects, DoubleVec* scores = 0);
 
+    cv::Mat draw(bool gpu); // debug routine
+    void clear();
+    
 protected:
     void init(const cv::Mat& I);
     void initContext();

--- a/src/app/acf/LaunchScreen.storyboard
+++ b/src/app/acf/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/src/app/acf/acf.cpp
+++ b/src/app/acf/acf.cpp
@@ -372,6 +372,7 @@ int gauze_main(int argc, char** argv)
                     // then we dump both the CPU and the GPU pyramids and we use a reset()
                     // method in order to ensure the CPU pyramid will be computed for each
                     // frame.
+#if defined(ACF_DO_GPU)
                     if(acf::GLDetector *handle = dynamic_cast<acf::GLDetector*>(detector.get()))
                     {
                         cv::Mat Pcpu = handle->draw(false);
@@ -380,6 +381,7 @@ int gauze_main(int argc, char** argv)
                         cv::imwrite(filename + "_Pgpu.png", Pgpu);
                         handle->clear();
                     }
+#endif
                 }
 
                 if (doScoreLog)

--- a/src/app/acf/plist.in
+++ b/src/app/acf/plist.in
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE
+    plist
+    PUBLIC
+    "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd"
+>
+<plist version="1.0">
+<dict>
+  <!--
+  String below icon (XCODE_ATTRIBUTE_PRODUCT_NAME)
+  -->
+  <key>CFBundleDisplayName</key>
+  <string>$(PRODUCT_NAME)</string>
+
+  <!--
+  Internal name of executable file
+  e.g.: ProductName.app/ExecutableName
+  NOTE: This key is required (!)
+  Initialized automatically by Xcode (no need to modify cmake target property)
+  (XCODE_ATTRIBUTE_EXECUTABLE_NAME)
+  -->
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+
+  <!--
+  Bundle identifier. Unique id, usually reverse DNS:
+  e.g.: com.example.johndoe.awesomeproject
+  (XCODE_ATTRIBUTE_BUNDLE_IDENTIFIER)
+  -->
+  <key>CFBundleIdentifier</key>
+  <string>$(BUNDLE_IDENTIFIER)</string>
+
+  <!--
+  Storyboards
+  -->
+  <key>UILaunchStoryboardName</key>
+  <string>LaunchScreen</string>
+
+  <!--
+  Device supported orientations
+  -->
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <!--
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+    -->
+  </array>
+  <key>UISupportedInterfaceOrientations~ipad</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <!--
+    <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+    -->
+  </array>
+
+  <!--
+  Other
+  -->
+  <key>UIFileSharingEnabled</key>
+  <string>YES</string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.1</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>1.1</string>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>UIRequiredDeviceCapabilities</key>
+  <array>
+    <string>armv7</string>
+  </array>
+  <key>NSCameraUsageDescription</key>
+  <string>CAMERA</string>  
+</dict>
+</plist>

--- a/src/lib/acf/GPUACF.cpp
+++ b/src/lib/acf/GPUACF.cpp
@@ -198,28 +198,67 @@ struct ACF::Impl
             reduceGradHistProcASmooth->add(gradHistProcAOut.get()); // ### OUTPUT ###
         }
     }
-
+    
     // This provides a map for unpacking/swizzling OpenGL textures (i.e., RGBA or BGRA) to user
     // memory using NEON optimized instructions.
     ChannelSpecification getACFChannelSpecification(MatP& acf) const
     {
-        // clang-format on
+        // clang-format off
         const auto& rgba = m_rgba;
         switch (m_featureKind)
         {
             case kLUVM012345:
                 // 10 : { LUVMp; H0123p; H4567p } requires 3 textures
-                return ChannelSpecification{
-                    { { { acf[0], rgba[0] }, { acf[1], rgba[1] }, { acf[2], rgba[2] }, { acf[3], rgba[3] } }, mergeProcLUVG.get() },
-                    { { { acf[4], rgba[0] }, { acf[5], rgba[1] }, { acf[6], rgba[2] }, { acf[7], rgba[3] } }, reduceGradHistProcASmooth.get() },
-                    { { { acf[8], rgba[0] }, { acf[9], rgba[1] } }, reduceGradHistProcBSmooth.get() }
+                return ChannelSpecification
+                {
+                    {
+                        {
+                            { acf[0], rgba[0] },
+                            { acf[1], rgba[1] },
+                            { acf[2], rgba[2] },
+                            { acf[3], rgba[3] }
+                        },
+                        mergeProcLUVG.get()
+                    },
+                    {
+                        {
+                            { acf[4], rgba[0] },
+                            { acf[5], rgba[1] },
+                            { acf[6], rgba[2] },
+                            { acf[7], rgba[3] }
+                        },
+                        reduceGradHistProcASmooth.get()
+                    },
+                    {
+                        {
+                            { acf[8], rgba[0] },
+                            { acf[9], rgba[1] }
+                        },
+                        reduceGradHistProcBSmooth.get()
+                    }
                 };
 
             case kM012345:
                 // 7: { Mp; H0123p; H4567p } requires only 2 textures
-                return ChannelSpecification{
-                    { { { acf[0], rgba[1] }, { acf[5], rgba[2] }, { acf[6], rgba[3] } }, mergeProcLG56.get() },
-                    { { { acf[1], rgba[0] }, { acf[2], rgba[1] }, { acf[3], rgba[2] }, { acf[4], rgba[3] } }, reduceGradHistProcASmooth.get() }
+                return ChannelSpecification
+                {
+                    {
+                        {
+                            { acf[0], rgba[1] },
+                            { acf[5], rgba[2] },
+                            { acf[6], rgba[3] }
+                        },
+                        mergeProcLG56.get()
+                    },
+                    {
+                        {
+                            { acf[1], rgba[0] },
+                            { acf[2], rgba[1] },
+                            { acf[3], rgba[2] },
+                            { acf[4], rgba[3] }
+                        },
+                        reduceGradHistProcASmooth.get()
+                    }
                 };
             default:
                 CV_Assert(false);

--- a/src/lib/acf/gpu/gradhist.cpp
+++ b/src/lib/acf/gpu/gradhist.cpp
@@ -37,17 +37,18 @@ const char * GradHistProc::fshaderGradHistSrcN = OG_TO_STR
  void main()
  {
      vec4 val = texture2D(uInputTex, vTexCoord);
+     val.y *= (1.0 - step(1.0, val.y));
      float mag = val.x * strength;
-     float t = val.y * nOrientations; // (clamp(val.y, 0.0, 1.0) * nOrientations);
+     float t = val.y * nOrientations;
      vec2 k = floor(mod(floor(vec2(t, t+1.0)), nOrientations));
 
      float a = abs(t - k.x);
      float b = abs(1.0 - a);
      vec4 index0 = vec4(equal(ivec4(int(k.x)), index));
      vec4 index1 = vec4(equal(ivec4(int(k.y)), index));
-     vec4 final = mag * vec4((index0 * b) + (index1 * a));
+     vec4 result = mag * vec4((index0 * b) + (index1 * a));
 
-     gl_FragColor = final;
+     gl_FragColor = result;
  });
 // clang-format on
 END_OGLES_GPGPU

--- a/src/lib/acf/toolbox/gradientMex.cpp
+++ b/src/lib/acf/toolbox/gradientMex.cpp
@@ -135,6 +135,15 @@ public:
 #endif
         return a1[i];
     }
+    
+    const int max()
+    {
+        return +(n + b - 1);
+    };
+    const int min()
+    {
+        return -(n * b - 1);
+    };
 
     const static int n = 10000, b = 10;
 
@@ -190,6 +199,10 @@ void gradMag(float* I, float* M, float* O, int h, int w, int d, bool full)
     _Gx = (__m128*)Gx;
     Gy = (float*)alMalloc(s, 16);
     _Gy = (__m128*)Gy;
+    
+    __m128 upper = SET(static_cast<float>(ACosTable::getInstance().max()));
+    __m128 lower = SET(static_cast<float>(ACosTable::getInstance().min()));
+    
     // compute gradient magnitude and orientation for each column
     for (x = 0; x < w; x++)
     {
@@ -220,7 +233,7 @@ void gradMag(float* I, float* M, float* O, int h, int w, int d, bool full)
             {
                 _Gx[y] = MUL(MUL(_Gx[y], _m), SET(acMult));
                 _Gx[y] = XOR(_Gx[y], AND(_Gy[y], SET(-0.f)));
-                _Gx[y] = MAX_sse(MIN_sse(XOR(_Gx[y], AND(_Gy[y], SET(-0.f))), SET(acMult)), SET(-acMult));
+                _Gx[y] = MAX_sse(MIN_sse(_Gx[y], upper), lower); // prevent: NaN, -0.0
             }
         };
         memcpy(M + x * h, M2, h * sizeof(float));


### PR DESCRIPTION
* make acf a full fledged iOS acf-detect.app
    + XCODE_BUNDLE_IDENTIFIER for use with ios-deploy
    + add plist.in to support file sharing (viewable output files)
    + add command line option for dumping pyramids as flat images for analysis
    + is now compatible with ios-deploy
    + add argv preprocessing via regex_replace of regex(“HOME”)  w/ getenv(HOME) — this allows passing generic command line arguments from the command line for use with ios-deploy, since we don’t know the path of the installed executable and associated data (this is similar to the gauze generator expressions used for cross platform unit tests)

* add acf-detect test/tune features
    + add randomShapes() function to draw some random patterns w/ various colors (lines, ellipses, rectangles) — this was used initially to support gpu/cpu pyramid testing on mobile devices
    + support internal pyramid drawing for analysis
    + unify include style
    + make VideoSource respect “—random” command line option (a separate class can be added (possibly with the ability to insert random faces))

* clip gradient values to upper/lower bounds of the lookup table in gradientMex:gradMag() —  this replaces a more complex function that was most likely aiming to do the same thing but was actually incorrectly modifying the orientation bins

* fix gradhist shader multi-channel orientation histogramming binning interpolation logic (this was correct but missed an edge case where orientations of 1.0 were counted in the bin==1 instead of bin==0

* add dodecagon test image to the test files
* formatting
* add CMakeLists.txt code block describing  HUNTER_KEEP_PACKAGES_SOURCES option — somewhat pedantic, but a useful build configuration for development tasks
* workaround for OpenCV protobuf compiler crash w/ ios build for local builds — this may be limited to xcode 9.1 but should be fine since the opencv_dnn module isn’t used by acf anyway