### PR TITLE
opengl acf pyramid shader pipeline tuning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,9 +84,6 @@ else()
     HunterGate(
       URL "${ACF_HUNTER_GATE_URL}"
       SHA1 "${ACF_HUNTER_GATE_SHA1}"
-      # ******************
-      # *** FUTURE USE ***
-      # ******************
       FILEPATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/config.cmake"
     )
   endif()
@@ -96,7 +93,8 @@ endif()
 ### ACF project ###
 ###################
 
-project(acf VERSION 0.0.2)
+# See https://github.com/hunter-packages/check_ci_tag when changing VERSION
+project(acf VERSION 0.1.0)
 
 set(ACF_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 

--- a/src/lib/acf/draw.cpp
+++ b/src/lib/acf/draw.cpp
@@ -1,0 +1,47 @@
+/*! -*-c++-*-
+  @file   draw.cpp
+  @author David Hirvonen
+  @brief  Implementation of drawing routines related to ACF computation.
+
+  \copyright Copyright 2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#include <acf/draw.h>
+
+#include <opencv2/imgproc.hpp>
+
+ACF_NAMESPACE_BEGIN
+
+// This function demonstrates how to visualize a pyramid structure:
+cv::Mat draw(acf::Detector::Pyramid& pyramid)
+{
+   cv::Mat canvas;
+   std::vector<cv::Mat> levels;
+   for (int i = 0; i < pyramid.nScales; i++)
+   {
+       // Concatenate the transposed faces, so they are compatible with the GPU layout
+       cv::Mat Ccpu;
+       std::vector<cv::Mat> images;
+       for (const auto& image : pyramid.data[i][0].get())
+       {
+           images.push_back(image.t());
+       }
+       cv::vconcat(images, Ccpu);
+
+       // Instead of upright:
+       //cv::vconcat(pyramid.data[i][0].get(), Ccpu);
+
+       if (levels.size())
+       {
+           cv::copyMakeBorder(Ccpu, Ccpu, 0, levels.front().rows - Ccpu.rows, 0, 0, cv::BORDER_CONSTANT);
+       }
+
+       levels.push_back(Ccpu);
+   }
+   cv::hconcat(levels, canvas);
+   return canvas;
+}
+
+ACF_NAMESPACE_END

--- a/src/lib/acf/draw.h
+++ b/src/lib/acf/draw.h
@@ -1,0 +1,24 @@
+/*! -*-c++-*-
+  @file   draw.h
+  @author David Hirvonen
+  @brief  Declaration of drawing routines related to ACF computation.
+
+  \copyright Copyright 2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#ifndef __acf_draw_h__
+#define __acf_draw_h__
+
+#include <acf/ACF.h>
+
+#include <opencv2/core.hpp>
+
+ACF_NAMESPACE_BEGIN
+
+cv::Mat draw(acf::Detector::Pyramid& pyramid);
+
+ACF_NAMESPACE_END
+
+#endif // __acf_draw_h__

--- a/src/lib/acf/gpu/binomial.cpp
+++ b/src/lib/acf/gpu/binomial.cpp
@@ -1,0 +1,52 @@
+/*! -*-c++-*-
+  @file   binomial.cpp
+  @author David Hirvonen (C++ implementation)
+  @brief Implementation of an ogles_gpgpu binomial filter shader.
+
+  \copyright Copyright 2014-2016 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#include <acf/gpu/binomial.h>
+
+BEGIN_OGLES_GPGPU
+
+// clang-format off
+const char * BinomialProc::fshaderBinomialSrc = 
+#if defined(OGLES_GPGPU_OPENGLES)
+OG_TO_STR(precision highp float;)
+#endif
+OG_TO_STR(
+ varying vec2 textureCoordinate;
+ varying vec2 leftTextureCoordinate;
+ varying vec2 rightTextureCoordinate;
+
+ varying vec2 topTextureCoordinate;
+ varying vec2 topLeftTextureCoordinate;
+ varying vec2 topRightTextureCoordinate;
+
+ varying vec2 bottomTextureCoordinate;
+ varying vec2 bottomLeftTextureCoordinate;
+ varying vec2 bottomRightTextureCoordinate;
+
+ uniform sampler2D inputImageTexture;
+
+ void main()
+{
+    vec4 sw = texture2D(inputImageTexture, bottomLeftTextureCoordinate);
+    vec4 ne = texture2D(inputImageTexture, topRightTextureCoordinate);
+    vec4 nw = texture2D(inputImageTexture, topLeftTextureCoordinate);
+    vec4 se = texture2D(inputImageTexture, bottomRightTextureCoordinate);
+    vec4 w = texture2D(inputImageTexture, leftTextureCoordinate);
+    vec4 c = texture2D(inputImageTexture, textureCoordinate);
+    vec4 e = texture2D(inputImageTexture, rightTextureCoordinate);
+    vec4 s = texture2D(inputImageTexture, bottomTextureCoordinate);
+    vec4 n = texture2D(inputImageTexture, topTextureCoordinate);
+
+    vec4 final = (sw + ne + nw + se) / 16.0 + (n + s + w + e) / 8.0 + c / 4.0;
+
+    gl_FragColor = final;
+});
+END_OGLES_GPGPU
+// clang-format on

--- a/src/lib/acf/gpu/binomial.h
+++ b/src/lib/acf/gpu/binomial.h
@@ -1,0 +1,43 @@
+/*! -*-c++-*-
+  @file   binomial.h
+  @author David Hirvonen (C++ implementation)
+  @brief Declaration of an ogles_gpgpu binomial filter shader.
+
+  \copyright Copyright 2014-2016 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#ifndef __acf_gpu_binomial_h__
+#define __acf_gpu_binomial_h__
+
+#include <ogles_gpgpu/common/proc/filter3x3.h>
+
+BEGIN_OGLES_GPGPU
+
+class BinomialProc : public ogles_gpgpu::Filter3x3Proc
+{
+public:
+    BinomialProc() {}
+    virtual const char* getProcName()
+    {
+        return "BinomialProc";
+    }
+
+private:
+    virtual const char* getFragmentShaderSource()
+    {
+        return fshaderBinomialSrc;
+    }
+    virtual void getUniforms()
+    {
+        Filter3x3Proc::getUniforms();
+        shParamUInputTex = shader->getParam(UNIF, "inputImageTexture");
+    }
+    virtual void setUniforms() {}
+    static const char* fshaderBinomialSrc; // fragment shader source
+};
+
+END_OGLES_GPGPU
+
+#endif //  __acf_gpu_binomial_h__

--- a/src/lib/acf/gpu/multipass/triangle_pass.cpp
+++ b/src/lib/acf/gpu/multipass/triangle_pass.cpp
@@ -71,6 +71,10 @@ std::string fragmentShaderForTriangle(int blurRadius, bool doNorm = false, int p
     int numberOfOffsets = optimizedTriangleOffsets.size();
 
     std::stringstream ss;
+#if defined(OGLES_GPGPU_OPENGLES)
+    ss << "precision highp float;\n";
+    ss << "\n";
+#endif
     ss << "uniform sampler2D inputImageTexture;\n";
     ss << "uniform float texelWidthOffset;\n";
     ss << "uniform float texelHeightOffset;\n\n";
@@ -78,7 +82,7 @@ std::string fragmentShaderForTriangle(int blurRadius, bool doNorm = false, int p
     ss << "void main()\n";
     ss << "{\n";
     ss << "   vec4 sum = vec4(0.0);\n";
-    ss << "   vec4 center = texture2D(inputImageTexture, blurCoordinates[0]);\n";
+    ss << "   vec4 center = texture2D(inputImageTexture, blurCoordinates[" << numberOfOffsets/2 << "]);\n";
 
     for (int currentBlurCoordinateIndex = 0; currentBlurCoordinateIndex < numberOfOffsets; currentBlurCoordinateIndex++)
     {
@@ -113,15 +117,8 @@ void TriangleProcPass::setRadius(int radius)
     if (radius != _blurRadiusInPixels)
     {
         _blurRadiusInPixels = radius;
-
-        //std::cout << "Blur radius " << _blurRadiusInPixels << " calculated sample radius " << calculatedSampleRadius << std::endl;
-        //std::cout << "===" << std::endl;
-
         vshaderTriangleSrc = vertexShaderForTriangle(radius);
         fshaderTriangleSrc = fragmentShaderForTriangle(radius, doNorm, renderPass, normConst);
-
-        std::cout << vshaderTriangleSrc << std::endl;
-        std::cout << fshaderTriangleSrc << std::endl;
     }
 }
 

--- a/src/lib/acf/sugar.cmake
+++ b/src/lib/acf/sugar.cmake
@@ -22,6 +22,7 @@ sugar_files(ACF_SRCS
   chnsCompute.cpp
   chnsPyramid.cpp
   convTri.cpp
+  draw.cpp
   gradientHist.cpp
   gradientMag.cpp
   rgbConvert.cpp
@@ -42,6 +43,7 @@ sugar_files(ACF_HDRS
   ACFIOArchive.h
   ACFObject.h
   ObjectDetector.h
+  draw.h
   #######################
   ### Toolbox headers ###
   #######################  
@@ -66,6 +68,7 @@ if(ACF_BUILD_OGLES_GPGPU)
     gpu/multipass/triangle_pass.h
     gpu/swizzle2.h
     gpu/triangle.h
+    gpu/binomial.h
     )
   sugar_files(ACF_SRCS
     GPUACF.cpp
@@ -73,5 +76,6 @@ if(ACF_BUILD_OGLES_GPGPU)
     gpu/multipass/triangle_pass.cpp
     gpu/swizzle2.cpp
     gpu/triangle.cpp
+    gpu/binomial.cpp
     )
 endif()


### PR DESCRIPTION
* various updates to help close the gap between the cpu and gpu output
* replace GaussOptProc with separable TriangleProc filter + fix phase offset in fragmentShaderForTriangle(…)
* move `cv::Mat draw(acf::Detector::Pyramid& pyramid)` to core lib (reuse!)
* standardize gaussian smoothing + reduction for each resize
* formatting and comments, and remove static for local scale/shrink term
* add binomial filter (support experimentation)
* bump acf version to 0.1.0