### PR TITLE
add gpu accelerated acf sample

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ cmake_minimum_required(VERSION 3.9) # CMAKE_INTERPROCEDURAL_OPTIMIZATION
 # using HUNTER_CONFIGURATION_TYPES=Release
 
 # https://docs.hunter.sh/en/latest/reference/user-variables.html#hunter-keep-package-sources
-option(HUNTER_KEEP_PACKAGE_SOURCES "Keep installed package sources for debugging (caveat...)" OFF)
+option(HUNTER_KEEP_PACKAGE_SOURCES "Keep installed package sources for debugging (caveat...)" ON)
 
 #########################
 ### CMAKE_MODULE_PATH ###

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,9 +1,3 @@
-#############
-### Boost ###
-#############
-#hunter_add_package(Boost COMPONENTS filesystem system)
-#find_package(Boost CONFIG REQUIRED filesystem system)  
-
 ###############
 ### cxxopts ### :: std::regex >= gcc 4.8
 ###############
@@ -11,3 +5,5 @@ hunter_add_package(cxxopts)
 find_package(cxxopts CONFIG REQUIRED)
 
 add_subdirectory(acf)
+
+add_subdirectory(pipeline)

--- a/src/app/acf/CMakeLists.txt
+++ b/src/app/acf/CMakeLists.txt
@@ -38,14 +38,6 @@ set_target_properties(
   XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2" # iPhone/iPad
 )
 
-# gauze_add_test(
-#   NAME AcfDetect
-#   COMMAND ${test_app}
-#   "IOS_TEST"
-#   "$<GAUZE_RESOURCE_FILE:${DRISHTI_ASSETS_FACE_DETECTOR}>"
-#   "$<GAUZE_RESOURCE_FILE:${ACF_DODECAGON_IMAGE}>"
-# )
-
 ###############
 ### mat2cpb ###
 ###############

--- a/src/app/acf/acf.cpp
+++ b/src/app/acf/acf.cpp
@@ -308,7 +308,12 @@ int gauze_main(int argc, char** argv)
         // Get thread specific segmenter lazily:
         auto& detector = manager[std::this_thread::get_id()];
         assert(detector);
-        const auto winSize = detector->getWindowSize();
+        
+        auto winSize = detector->getWindowSize();
+        if(!detector->getIsRowMajor())
+        {
+            std::swap(winSize.width, winSize.height);
+        }
 
         // Load current image
         auto frame = (*video)(i);

--- a/src/app/pipeline/CMakeLists.txt
+++ b/src/app/pipeline/CMakeLists.txt
@@ -1,0 +1,45 @@
+set(test_app acf-pipeline)
+
+####################
+### acf-pipeline ###
+####################
+
+# Define list of sources, add gpu files as needed
+set(acf_srcs 
+  pipeline.cpp
+  GPUDetectionPipeline.h
+  GPUDetectionPipeline.cpp
+  
+  # Simple line segment shader for the usual green box annotations:
+  lines.h
+  lines.cpp
+)
+
+add_executable(${test_app} ${acf_srcs})
+target_link_libraries(${test_app} PUBLIC acf cxxopts::cxxopts ${OpenCV_LIBS})
+
+# thread-pool-cpp:
+hunter_add_package(thread-pool-cpp)
+find_package(thread-pool-cpp CONFIG REQUIRED)
+target_link_libraries(${test_app} PUBLIC thread-pool-cpp::thread-pool-cpp)
+
+# aglet (opengl context):
+hunter_add_package(aglet)
+find_package(aglet CONFIG REQUIRED)
+target_link_libraries(${test_app} PUBLIC aglet::aglet)
+
+target_include_directories(${test_app} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../>")
+target_compile_definitions(${test_app} PUBLIC ACF_DO_GPU=1)
+
+set_property(TARGET ${test_app} PROPERTY FOLDER "app/console")
+install(TARGETS ${test_app} DESTINATION bin)
+
+set_target_properties(
+  ${test_app}
+  PROPERTIES
+  MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_LIST_DIR}/plist.in" # file sharing
+  XCODE_ATTRIBUTE_PRODUCT_NAME "${test_app}"
+  XCODE_ATTRIBUTE_BUNDLE_IDENTIFIER "com.elucideye.acf.${test_app}"
+  XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.elucideye.acf.${test_app}"
+  XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2" # iPhone/iPad
+)

--- a/src/app/pipeline/GPUDetectionPipeline.cpp
+++ b/src/app/pipeline/GPUDetectionPipeline.cpp
@@ -1,0 +1,400 @@
+#include "GPUDetectionPipeline.h"
+#include "lines.h"
+
+#include <ogles_gpgpu/common/proc/fifo.h> // ogles_gpgpu::FifoProc
+
+#include <thread_pool/thread_pool.hpp> // tp::ThreadPool<>
+
+#include <util/make_unique.h>
+
+#include <thread>
+#include <deque>
+#include <memory>
+
+static void chooseBest(std::vector<cv::Rect>& objects, std::vector<double>& scores);
+
+template <typename Container>
+void push_fifo(Container& container, const typename Container::value_type& value, int size)
+{
+    container.push_front(value);
+    if (container.size() > size)
+    {
+        container.pop_back();
+    }
+}
+
+template <typename T1, typename T2>
+cv::Size_<T1> operator*(const cv::Size_<T1>& src, const T2& scale)
+{
+    return cv::Size_<T1>(T2(src.width) * scale, T2(src.height) * scale);
+}
+
+template <typename T1, typename T2>
+cv::Point_<T1> operator*(const cv::Point_<T1>& src, const T2& scale)
+{
+    return cv::Point_<T1>(T2(src.x) * scale, T2(src.y) * scale);
+}
+
+template <typename T1, typename T2>
+cv::Rect_<T1> operator*(const cv::Rect_<T1>& src, const T2& scale)
+{
+    return cv::Rect_<T1>(src.tl() * scale, src.size() * scale);
+}
+
+ACF_NAMESPACE_BEGIN
+
+struct GPUDetectionPipeline::Impl
+{
+    using time_point = std::chrono::high_resolution_clock::time_point;
+
+    Impl(GPUDetectionPipeline::DetectionPtr& detector)
+        : detector(detector)
+    {
+        threads = util::make_unique<tp::ThreadPool<>>();
+    }
+
+    ~Impl() = default;
+
+    std::shared_ptr<acf::Detector> detector;
+
+    int history = 3; // frame history
+    int latency = 2;
+    int outputOrientation = 0;
+    int minObjectWidth = 0;
+
+    void* glContext = nullptr;
+    bool usePBO = false;
+    int glVersionMajor = 2;
+
+    bool getImage = false;
+
+    bool doSingleObject = false;
+    std::pair<time_point, std::vector<cv::Rect>> objects;
+
+    std::vector<DetectionCallback> callbacks;
+
+    uint64_t frameIndex = 0;
+    float ACFScale = 1.f;
+    float acfCalibration = 0.f;
+    std::vector<cv::Size> pyramidSizes;
+    acf::Detector::Pyramid P;
+    std::unique_ptr<ogles_gpgpu::ACF> acf;
+    std::unique_ptr<ogles_gpgpu::FifoProc> fifo; // store last N faces
+
+    std::shared_ptr<tp::ThreadPool<>> threads;
+    std::future<Detections> scene;
+    std::deque<Detections> scenePrimitives; // stash
+
+    // Show a line annotator:
+    ogles_gpgpu::LineProc lines;
+};
+
+GPUDetectionPipeline::GPUDetectionPipeline(DetectionPtr& detector, const cv::Size& inputSize, std::size_t n, int rotation, int minObjectWidth)
+{
+    impl = util::make_unique<Impl>(detector);
+    impl->minObjectWidth = minObjectWidth;
+    init(inputSize);
+}
+
+GPUDetectionPipeline::~GPUDetectionPipeline()
+{
+    try
+    {
+        // If this has already been retrieved it will throw
+        impl->scene.get(); // block on any abandoned calls
+    }
+    catch (std::exception& e)
+    {
+    }
+}
+
+void GPUDetectionPipeline::operator+=(const DetectionCallback& callback)
+{
+    impl->callbacks.push_back(callback);
+}
+
+void GPUDetectionPipeline::init(const cv::Size& inputSize)
+{
+    // Get the upright size:
+    auto inputSizeUp = inputSize;
+    bool hasTranspose = ((impl->outputOrientation / 90) % 2);
+    if (hasTranspose)
+    {
+        std::swap(inputSizeUp.width, inputSizeUp.height);
+    }
+
+    initACF(inputSizeUp);                 // initialize ACF first (configure opengl platform extensions)
+    initFIFO(inputSizeUp, impl->history); // keep last N frames
+
+    impl->lines.prepare(inputSizeUp.width, inputSizeUp.height, (GLenum)GL_RGBA);
+}
+
+// ### ACF ###
+
+// Side effect: set impl->pyramdSizes
+void GPUDetectionPipeline::initACF(const cv::Size& inputSizeUp)
+{
+    // ### ACF (Transpose) ###
+    // Find the detection image width required for object detection at the max distance:
+    const int detectionWidth = computeDetectionWidth(inputSizeUp);
+    impl->ACFScale = float(inputSizeUp.width) / float(detectionWidth);
+
+    // ACF implementation uses reduced resolution transposed image:
+    cv::Size detectionSize = inputSizeUp * (1.0f / impl->ACFScale);
+    cv::Mat I(detectionSize.width, detectionSize.height, CV_32FC3, cv::Scalar::all(0));
+
+    MatP Ip(I);
+    impl->detector->computePyramid(Ip, impl->P);
+
+    if (impl->P.nScales <= 0)
+    {
+        throw std::runtime_error("There are no valid detections scales for your provided configuration");
+    }
+
+    const auto& pChns = impl->detector->opts.pPyramid->pChns;
+    const int shrink = pChns->shrink.get();
+
+    impl->pyramidSizes.resize(impl->P.nScales);
+    std::vector<ogles_gpgpu::Size2d> sizes(impl->P.nScales);
+    for (int i = 0; i < impl->P.nScales; i++)
+    {
+        const auto size = impl->P.data[i][0][0].size();
+        sizes[i] = { size.width * shrink, size.height * shrink };
+        impl->pyramidSizes[i] = { size.width * shrink, size.height * shrink };
+
+        // CPU processing works with tranposed images for col-major storage assumption.
+        // Undo that here to map to row major representation.  Perform this step
+        // to make transpose operation explicit.
+        if (!impl->detector->getIsRowMajor())
+        {
+            std::swap(sizes[i].width, sizes[i].height);
+            std::swap(impl->pyramidSizes[i].width, impl->pyramidSizes[i].height);
+        }
+    }
+
+    const int grayWidth = 0;
+    //const int grayWidth = impl->doLandmarks ? std::min(inputSizeUp.width, impl->landmarksWidth) : 0;
+    const auto featureKind = ogles_gpgpu::getFeatureKind(*pChns);
+
+    CV_Assert(featureKind != ogles_gpgpu::ACF::kUnknown);
+
+    const ogles_gpgpu::Size2d size(inputSizeUp.width, inputSizeUp.height);
+    impl->acf = util::make_unique<ogles_gpgpu::ACF>(impl->glContext, size, sizes, featureKind, grayWidth, shrink);
+    impl->acf->setRotation(impl->outputOrientation);
+    impl->acf->setUsePBO((impl->glVersionMajor >= 3) && impl->usePBO);
+}
+
+// ### Fifo ###
+void GPUDetectionPipeline::initFIFO(const cv::Size& inputSize, std::size_t n)
+{
+    impl->fifo = util::make_unique<ogles_gpgpu::FifoProc>(n);
+    impl->fifo->init(inputSize.width, inputSize.height, INT_MAX, false);
+    impl->fifo->createFBOTex(false);
+}
+
+int GPUDetectionPipeline::computeDetectionWidth(const cv::Size& inputSizeUp) const
+{
+    auto winSize = impl->detector->getWindowSize();
+    if (!impl->detector->getIsRowMajor())
+    {
+        std::swap(winSize.width, winSize.height);
+    }
+
+    if (impl->minObjectWidth > 0)
+    {
+        return inputSizeUp.width * winSize.width / impl->minObjectWidth;
+    }
+    else
+    {
+        return inputSizeUp.width;
+    }
+}
+
+void GPUDetectionPipeline::fill(acf::Detector::Pyramid& P)
+{
+    impl->acf->fill(P, impl->P);
+}
+
+void GPUDetectionPipeline::computeAcf(const ogles_gpgpu::FrameInput& frame, bool doLuv, bool doDetection)
+{
+    glDisable(GL_BLEND);
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_DITHER);
+    glDepthMask(GL_FALSE);
+
+    impl->acf->setDoLuvTransfer(doLuv);
+    impl->acf->setDoAcfTrasfer(doDetection);
+
+    (*impl->acf)(frame);
+}
+
+GLuint GPUDetectionPipeline::paint(const Detections& scene, GLuint inputTexture)
+{
+
+    //if(impl->lines)
+    {
+        std::vector<std::array<float, 2>> segments;
+        for (const auto& r : scene.roi)
+        {
+            cv::Point2f tl = r.tl(), br = r.br(), tr(br.x, tl.y), bl(tl.x, br.y);
+
+            segments.push_back({ { tl.x, tl.y } });
+            segments.push_back({ { tr.x, tr.y } });
+
+            segments.push_back({ { tr.x, tr.y } });
+            segments.push_back({ { br.x, br.y } });
+
+            segments.push_back({ { br.x, br.y } });
+            segments.push_back({ { bl.x, bl.y } });
+
+            segments.push_back({ { bl.x, bl.y } });
+            segments.push_back({ { tl.x, tl.y } });
+        }
+
+        impl->lines.setLineSegments(segments);
+        impl->lines.process(inputTexture, 1, GL_TEXTURE_2D);
+        return impl->lines.getOutputTexId();
+    }
+
+    return inputTexture;
+}
+
+int GPUDetectionPipeline::detectOnly(Detections& scene, bool doDetection)
+{
+    // Fill in ACF Pyramid structure.
+    // Check to see if detection was already computed
+    if (doDetection)
+    {
+        std::vector<double> scores;
+        (*impl->detector)(*scene.P, scene.roi, &scores);
+
+        for (auto& r : scene.roi)
+        {
+            r = r * impl->ACFScale;
+        }
+
+        if (impl->doSingleObject)
+        {
+            chooseBest(scene.roi, scores);
+        }
+        impl->objects = std::make_pair(HighResolutionClock::now(), scene.roi);
+    }
+    else
+    {
+        scene.roi = impl->objects.second;
+    }
+
+    return scene.roi.size();
+}
+
+int GPUDetectionPipeline::detect(const ogles_gpgpu::FrameInput& frame, Detections& scene, bool doDetection)
+{
+    if (impl->detector && (!doDetection || scene.P))
+    {
+        if (!scene.roi.size())
+        {
+            detectOnly(scene, doDetection);
+        }
+    }
+
+    return 0;
+}
+
+std::pair<GLuint, Detections> GPUDetectionPipeline::operator()(const ogles_gpgpu::FrameInput& frame2, bool doDetection)
+{
+    ogles_gpgpu::FrameInput frame1;
+    frame1.size = frame2.size;
+
+    Detections scene2(impl->frameIndex), scene1, scene0, *outputScene = &scene2;
+
+    if (impl->fifo->getBufferCount() > 0)
+    {
+        // read GPU results for frame n-1
+
+        // Here we always trigger GPU pipeline reads
+        // to ensure upright + redeuced grayscale images will
+        // be available for regression, even if we won't be using ACF detection.
+        impl->acf->getChannels();
+
+        if (impl->acf->getChannelStatus())
+        {
+            // If the ACF textures were loaded in the last call, then we know
+            // that detections were requrested for the last frame, and we will
+            // populate an ACF pyramid for the detection step.
+            scene1.P = std::make_shared<decltype(impl->P)>();
+            fill(*scene1.P);
+        }
+
+        // ### Grayscale image ###
+        if (impl->getImage)
+        {
+            scene1.image = impl->acf->getGrayscale();
+        }
+    }
+
+    // Start GPU pipeline for the current frame, immediately after we have
+    // retrieved results for the previous frame.
+    computeAcf(frame2, false, doDetection);
+    GLuint texture2 = impl->acf->first()->getOutputTexId(), texture0 = 0, outputTexture = texture2;
+
+    if (impl->fifo->getBufferCount() > 0)
+    {
+        if (impl->fifo->getBufferCount() > 1)
+        {
+            // Retrieve CPU processing for frame n-2
+            scene0 = impl->scene.get();                     // scene n-2
+            texture0 = (*impl->fifo)[-2]->getOutputTexId(); // texture n-2
+
+            outputTexture = paint(scene0, texture0);
+            outputScene = &scene0;
+        }
+
+        // Run CPU detection + regression for frame n-1
+        impl->scene = impl->threads->process([scene1, frame1, this]() {
+            Detections sceneOut = scene1;
+            detect(frame1, sceneOut, scene1.P != nullptr);
+            return sceneOut;
+        });
+    }
+
+    // Maintain a history for last N textures and scenes.
+    // Note that with the current optimized pipeline (i.e., runFast) we introduce a latency of T=2
+    // so when we the texture for time T=2 to the OpenGL FIFO we wil push the most recent available
+    // scene for T-2 (T=0) to our scene buffer.
+    //
+    // IMAGE : { image[n-0], image[n-1], image[n-2] }
+    // SCENE : { __________, __________, scene[n-2], ... }
+
+    // Add the current frame to FIFO
+    impl->fifo->useTexture(texture2, 1);
+    impl->fifo->render();
+
+    // Clear face motion estimate, update window
+    push_fifo(impl->scenePrimitives, *outputScene, impl->history);
+
+    for (auto& c : impl->callbacks)
+    {
+        c(outputTexture, *outputScene);
+    }
+
+    return std::make_pair(outputTexture, *outputScene);
+}
+
+ACF_NAMESPACE_END
+
+static void chooseBest(std::vector<cv::Rect>& objects, std::vector<double>& scores)
+{
+    if (objects.size() > 1)
+    {
+        int best = 0;
+        for (int i = 1; i < objects.size(); i++)
+        {
+            if (scores[i] > scores[best])
+            {
+                best = i;
+            }
+        }
+        objects = { objects[best] };
+        scores = { scores[best] };
+    }
+}

--- a/src/app/pipeline/GPUDetectionPipeline.h
+++ b/src/app/pipeline/GPUDetectionPipeline.h
@@ -1,0 +1,74 @@
+/*! -*-c++-*-
+  @file   GPUDetectionPipeline.h
+  @author David Hirvonen
+  @brief  Pipeline for efficient GPU feature computation
+
+  \copyright Copyright 2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#ifndef __acf_GPUDetectionPipeline_h__
+#define __acf_GPUDetectionPipeline_h__
+
+#include <acf/GPUACF.h>
+#include <memory>
+#include <chrono>
+
+ACF_NAMESPACE_BEGIN
+
+struct Detections
+{
+    Detections() {}
+    Detections(std::uint64_t frameIndex)
+        : frameIndex(frameIndex)
+    {
+    }
+
+    std::uint64_t frameIndex;
+    cv::Mat image;
+    std::vector<cv::Rect> roi;
+    std::shared_ptr<acf::Detector::Pyramid> P;
+};
+
+class GPUDetectionPipeline
+{
+public:
+    using HighResolutionClock = std::chrono::high_resolution_clock;
+    using TimePoint = HighResolutionClock::time_point; // <std::chrono::system_clock>;
+    using DetectionPtr = std::shared_ptr<acf::Detector>;
+    using DetectionCallback = std::function<void(GLuint texture, const Detections& detections)>;
+
+    GPUDetectionPipeline(DetectionPtr& detector, const cv::Size& inputSize, std::size_t n, int rotation, int minObjectWidth);
+    virtual ~GPUDetectionPipeline();
+
+    // This method receives an input frame descriptor (pixel buffer or texture ID) on which to run 
+    // ACF object detection.  The doDetection parameter is provided in order to allow the user to 
+    // control the duty cycle of the detector (perhaps adaptively).  The detection pipeline introduces 
+    // two frames of latency so that the GPU->CPU overhead can be hidden.  For input frame N, the results
+    // are returned for frame N-2 (along with the corresponding texture ID).
+    std::pair<GLuint, Detections> operator()(const ogles_gpgpu::FrameInput& frame, bool doDetection=true);
+ 
+    void operator+=(const DetectionCallback& callback);
+
+protected:
+
+    // Allow user defined object detection drawing via inheritance.
+    virtual GLuint paint(const Detections& scene, GLuint inputTexture);
+
+    int detectOnly(Detections& scene, bool doDetection);
+    int detect(const ogles_gpgpu::FrameInput& frame, Detections& scene, bool doDetection);
+    void fill(acf::Detector::Pyramid& P);
+    void init(const cv::Size& inputSize);
+    void initACF(const cv::Size& inputSizeUp);
+    void initFIFO(const cv::Size& inputSize, std::size_t n);
+    void computeAcf(const ogles_gpgpu::FrameInput& frame, bool doLuv, bool doDetection);
+    int computeDetectionWidth(const cv::Size& inputSizeUp) const;
+
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+};
+
+ACF_NAMESPACE_END
+
+#endif // __acf_GPUDetectionPipeline_h__

--- a/src/app/pipeline/lines.cpp
+++ b/src/app/pipeline/lines.cpp
@@ -1,0 +1,139 @@
+/*! -*-c++-*-
+  @file   lines.cpp
+  @author David Hirvonen
+  @brief Implementation of ogles_gpgpu shader for drawing lines.
+
+  \copyright Copyright 2017-2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#include "lines.h"
+
+BEGIN_OGLES_GPGPU
+
+// clang-format off
+const char * LineShader::vshaderColorSrc = OG_TO_STR
+(
+ attribute vec4 position;
+ uniform mat4 modelViewProjMatrix;
+ 
+ void main()
+ {
+     gl_Position = modelViewProjMatrix * position;
+ });
+// clang-format on
+
+// clang-format off
+const char * LineShader::fshaderColorSrc = 
+#if defined(OGLES_GPGPU_OPENGLES)
+OG_TO_STR(precision highp float;)
+#endif
+OG_TO_STR(
+ uniform vec3 lineColor;
+ void main()
+ {
+     gl_FragColor = vec4(lineColor, 1.0);
+ });
+// clang-format on
+
+LineShader::LineShader()
+{
+    // Compile utility line shader:
+    shader = std::make_shared<Shader>();
+    if (!shader->buildFromSrc(vshaderColorSrc, fshaderColorSrc))
+    {
+        throw std::runtime_error("LineShader: shader error");
+    }
+    shParamUColor = shader->getParam(UNIF, "lineColor");
+    shParamUMVP = shader->getParam(UNIF, "modelViewProjMatrix");
+    shParamAPosition = shader->getParam(ATTR, "position");
+}
+
+const char* LineShader::getProcName()
+{
+    return "LineShader";
+}
+
+void LineShader::setLineSegments(const std::vector<Point2d>& segments)
+{
+    points = segments;
+}
+
+void LineShader::setModlViewTransformation(const Mat44f& mvp)
+{
+    MVP = mvp;
+}
+
+void LineShader::draw(int outFrameW, int outFrameH)
+{
+    glLineWidth(8);
+
+    if (points.size())
+    {
+        shader->use();
+        glUniform3f(shParamUColor, color[0], color[1], color[2]);
+        glUniformMatrix4fv(shParamUMVP, 1, 0, &MVP.data[0][0]);
+        glViewport(0, 0, outFrameW, outFrameH);
+        glVertexAttribPointer(shParamAPosition, 2, GL_FLOAT, 0, 0, &points.data()[0]);
+        glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(points.size()));
+
+        Tools::checkGLErr(getProcName(), "draw()");
+    }
+};
+
+// : : : : : : : : : : : : : : : : : :
+
+// clang-format off
+const char * LineProc::fshaderLineSrc =
+#if defined(OGLES_GPGPU_OPENGLES)
+OG_TO_STR(precision mediump float;)
+#endif
+OG_TO_STR(
+varying vec2 vTexCoord;
+uniform sampler2D uInputTex;
+void main()
+{
+    gl_FragColor = texture2D(uInputTex, vTexCoord);
+});
+
+
+static void imageToTexture(ogles_gpgpu::Mat44f &MVP, int width, int height)
+{
+    for(int y = 0; y < 4; y++)
+    {
+        for(int x = 0; x < 4; x++)
+        {
+            MVP.data[y][x] = 0.f;
+        }
+    }
+    MVP.data[0][0] = 2.f / static_cast<float>(width);
+    MVP.data[1][1] = 2.f / static_cast<float>(height);
+    MVP.data[2][2] = 1.f;
+    MVP.data[3][3] = 1.f;
+    
+    MVP.data[3][0] = -1.f; // apply x translation transposed
+    MVP.data[3][1] = -1.f; // apply y translation transposed
+}
+
+void LineProc::filterRenderDraw()
+{
+    ogles_gpgpu::Mat44f MVP;
+    imageToTexture(MVP, getOutFrameW(), getOutFrameH());
+  
+    ogles_gpgpu::FilterProcBase::filterRenderDraw();
+    lines.setModlViewTransformation(MVP);
+    lines.draw(getOutFrameW(), getOutFrameH());
+}
+
+void LineProc::setLineSegments(const std::vector<Point2d> &points)
+{
+    lines.setLineSegments(points);
+}
+
+void LineProc::setModlViewTransformation(const Mat44f &mvp)
+{
+    lines.setModlViewTransformation(mvp);
+}
+
+END_OGLES_GPGPU

--- a/src/app/pipeline/lines.h
+++ b/src/app/pipeline/lines.h
@@ -1,0 +1,81 @@
+/*! -*-c++-*-
+  @file   lines.h
+  @author David Hirvonen
+  @brief Declaration of ogles_gpgpu shader for drawing lines.
+
+  \copyright Copyright 2017-2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#ifndef __acf_LineShader_h__
+#define __acf_LineShader_h__
+
+#include <ogles_gpgpu/common/proc/base/filterprocbase.h>
+
+#include <array>
+#include <memory>
+
+BEGIN_OGLES_GPGPU
+
+// Ideally we would use GL_TRIANGLES + glPolygonMode(GL_FRONT_AND_BACK,GL_LINE);
+// However, this isn't supported in OpenGL ES
+// https://stackoverflow.com/a/29583687
+// https://stackoverflow.com/a/4063084
+
+class LineShader
+{
+public:
+    using Point2d = std::array<float, 2>;
+
+    LineShader();
+
+    static const char* getProcName();
+    void draw(int outFrameW, int outFrameH);
+    void setModlViewTransformation(const Mat44f& mvp);
+    void setLineSegments(const std::vector<Point2d>& segments);
+
+protected:
+    std::shared_ptr<Shader> shader;
+
+    static const char* vshaderColorSrc;
+    static const char* fshaderColorSrc;
+
+    GLint shParamUColor;
+    GLint shParamUMVP;
+    GLint shParamAPosition;
+
+    std::vector<Point2d> points;
+    std::array<float, 3> color = { { 0.f, 1.f, 0.f } };
+    Mat44f MVP;
+};
+
+class LineProc : public ogles_gpgpu::FilterProcBase
+{
+public:
+    using Point2d = std::array<float, 2>;
+
+    LineProc() {}
+
+    virtual const char* getProcName()
+    {
+        return "LineProc";
+    }
+    virtual const char* getFragmentShaderSource()
+    {
+        return fshaderLineSrc;
+    }
+    virtual void filterRenderDraw();
+
+    void setLineSegments(const std::vector<Point2d>& segments);
+
+    void setModlViewTransformation(const Mat44f& mvp);
+
+    static const char* fshaderLineSrc; // fragment shader source
+
+    LineShader lines;
+};
+
+END_OGLES_GPGPU
+
+#endif // __drishti_graphics_LineShader_h__

--- a/src/app/pipeline/pipeline.cpp
+++ b/src/app/pipeline/pipeline.cpp
@@ -1,0 +1,282 @@
+/*! -*-c++-*-
+  @file   pipeline.cpp
+  @author David Hirvonen
+  @brief GPU accelerated ACF object detection application. 
+
+  This application performs GPU accelerated ACF object detection.
+  In particular, it makes use of the acf::GPUACF class (ogles_gpgpu shaders)
+  to compute ACF pyramids on the GPU in pure OpenGL, which are retrieved
+  (with latency) and used for "sliding window" multi-scale object detection 
+  on the CPU.
+
+  Since the object detection (gradient boosting w/ lots of random memory access)
+  doesn't map well to low end mobile GPU's, the multi-scale detection runs on
+  the CPU, but makes use of multi-scale ACF features from the GPU that don't
+  compute with CPU resources.  In most cases the GPU->CPU transfer will be a
+  significant bottleneck, and a naive implementation (src/app/acf/GLDetector.{h,cpp})
+  may very well run slower than the end-to-end CPU based implementation.
+
+  In this sample application, some latency is introduced and the GPU->CPU 
+  transfer overhead associated with the ACF pyramids is hidden in that time.  
+  This assumes the target application can tolerate a little latency to improve
+  overall throughput.  Even if the full CPU processing achieves the desired 
+  frame rate, it can be beneficial to offload the feature computation to the GPU
+  in order to reduce CPU load and power consumption.
+
+  In order to run this efficiently, you will also want to make sure that you
+  avoid searching for faces at unnecessary scales.  For example, if you have
+  high resolution input images, then it is very unlikely you will need to
+  search for faces down at the scales matching the object detection training
+  samples.  In ACF face detection publications, 80x80 has been shown to work
+  well in practice (good accuracy vs computation balance).  In most selfie
+  type face detection applications, at least, there is no need to search for 
+  faces of size 80x80, and an enormous amount of computation can be saved
+  by resizing the input images such that the smallest faces one wants to find
+  end up at matching the detector window size (i.e., 80x80 or thereabouts).
+
+  If we are using the drishti_face_gray_80x80.cpb model, then we may want to
+  call this application with the following parameters:
+
+  acf-pipeline \
+      --input=0 \
+      --model=${SOME_PATH_VAR}/drishti-assets/drishti_face_gray_80x80.cpb
+      --minimum=200 \
+      --calibration=0.01 \
+      --window
+
+  In the above command, "minimum=200" means we are ignoring all faces
+  less than 200 pixels wide.  You should set this to the largest value
+  that makes sense for your application. 
+
+  Note that the "calibration" term may also be required to achieve the
+  desired recall for a given detector.  See the ACF publications referenced
+  on the main README.rst page for additional details on this parameter.
+
+  \copyright Copyright 2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#include "GPUDetectionPipeline.h"
+
+#include <util/Logger.h>
+
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/highgui.hpp>
+
+#include <aglet/GLContext.h>
+
+#include <ogles_gpgpu/common/proc/disp.h>
+
+#include <cxxopts.hpp>
+
+// clang-format off
+#ifdef ANDROID
+#  define TEXTURE_FORMAT GL_RGBA
+#else
+#  define TEXTURE_FORMAT GL_BGRA
+#endif
+// clang-format on
+
+template <typename T>
+void* void_ptr(const T* ptr)
+{
+    return static_cast<void*>(const_cast<T*>(ptr));
+}
+
+static std::shared_ptr<cv::VideoCapture> create(const std::string& filename);
+static cv::Size getSize(cv::VideoCapture& video);
+
+struct Application
+{
+    // clang-format off
+    Application
+    (
+        const std::string &input,
+        const std::string &model,
+        float acfCalibration,
+        int minWidth,
+        bool window,
+        float resolution
+    ) : resolution(resolution)
+    // clang-format on
+    {
+        // Create a video source:
+        // 1) integar == index to device camera
+        // 2) filename == supported video formats
+        // 3) "/fullpath/Image_%03d.png" == list of stills
+        // http://answers.opencv.org/answers/761/revisions/
+        video = create(input);
+
+        // Create an OpenGL context:
+        const auto size = getSize(*video);
+        context = aglet::GLContext::create(aglet::GLContext::kAuto, window ? "acf" : "", size.width, size.height);
+
+        // Create an object detector:
+        detector = std::make_shared<acf::Detector>(model);
+        detector->setDoNonMaximaSuppression(true);
+        if (acfCalibration != 0.f)
+        {
+            acf::Detector::Modify dflt;
+            dflt.cascThr = { "cascThr", -1.0 };
+            dflt.cascCal = { "cascCal", acfCalibration };
+            detector->acfModify(dflt);
+        }
+
+        // Create the asynchronous scheduler:
+        pipeline = std::make_shared<acf::GPUDetectionPipeline>(detector, size, 5, 0, minWidth);
+
+        // Instantiate an ogles_gpgpu display class that will draw to the
+        // default texture (0) which will be managed by aglet (typically glfw)
+        if (window && context->hasDisplay())
+        {
+            display = std::make_shared<ogles_gpgpu::Disp>();
+            display->init(size.width, size.height, TEXTURE_FORMAT);
+            display->setOutputRenderOrientation(ogles_gpgpu::RenderOrientationFlipped);
+        }
+    }
+
+    void setLogger(std::shared_ptr<spdlog::logger>& logger)
+    {
+        this->logger = logger;
+    }
+
+    bool update()
+    {
+        cv::Mat frame;
+        (*video) >> frame;
+
+        if (frame.empty())
+        {
+            return false; // indicate failure, exit loop
+        }
+
+        if (frame.channels() == 3)
+        {
+// ogles_gpgpu supports both {BGR,RGB}A and NV{21,12} inputs, and
+// cv::VideoCapture support {RGB,BGR} output, so we need to add an
+// alpha plane.  Doing this on the CPU is wasteful, and it would be
+// better to access the camera directly for NV{21,12} processing
+#if ANDROID
+            cv::cvtColor(frame, frame, cv::COLOR_BGR2RGBA); // android need GL_RGBA
+#else
+            cv::cvtColor(frame, frame, cv::COLOR_BGR2BGRA); // assume all others are GL_BGRA
+#endif
+        }
+
+        auto result = (*pipeline)({ { frame.cols, frame.rows }, void_ptr(frame.data), true, false, TEXTURE_FORMAT }, true);
+
+        if (logger)
+        {
+            logger->info("OBJECTS : {}", result.second.roi.size());
+        }
+
+        if (display)
+        {
+            show(result.first);
+        }
+
+        return true; // continue sequence
+    }
+
+    void show(GLuint texture)
+    {
+        auto& geometry = context->getGeometry();
+        display->setOffset(geometry.tx, geometry.ty);
+        display->setDisplayResolution(geometry.sx * resolution, geometry.sy * resolution);
+        display->useTexture(texture);
+        display->render(0);
+    }
+
+    float resolution = 1.f;
+
+    std::shared_ptr<spdlog::logger> logger;
+
+    std::shared_ptr<aglet::GLContext> context;
+    std::shared_ptr<ogles_gpgpu::Disp> display;
+
+    std::shared_ptr<cv::VideoCapture> video;
+    std::shared_ptr<acf::Detector> detector;
+    std::shared_ptr<acf::GPUDetectionPipeline> pipeline;
+};
+
+int main(int argc, char** argv)
+{
+    auto logger = util::Logger::create("acf-pipeline");
+
+    bool help = false, doWindow = false;
+    float resolution = 1.f, acfCalibration = 0.f;
+    std::string sInput, sOutput, sModel;
+    int minWidth = 0;
+
+    const int argumentCount = argc;
+    cxxopts::Options options("acf-pipeline", "GPU accelerated ACF object detection (see Piotr's toolbox)");
+
+    // clang-format off
+    options.add_options()
+        ("i,input", "Input file", cxxopts::value<std::string>(sInput))
+        ("o,output", "Output directory", cxxopts::value<std::string>(sOutput))
+        ("m,model", "Model file", cxxopts::value<std::string>(sModel))
+        ("c,calibration", "ACF calibration", cxxopts::value<float>(acfCalibration))
+        ("r,resolution", "Resolution", cxxopts::value<float>(resolution))
+        ("w,window", "Window", cxxopts::value<bool>(doWindow))
+        ("M,minimum", "Minimum object width", cxxopts::value<int>(minWidth))
+        ("h,help", "Help message", cxxopts::value<bool>(help))
+        ;
+    // clang-format on
+
+    options.parse(argc, argv);
+    if ((argumentCount <= 1) || options.count("help"))
+    {
+        std::cout << options.help({ "" }) << std::endl;
+        return 0;
+    }
+
+    if (sModel.empty())
+    {
+        logger->error("Must specify a valid model");
+        return 1;
+    }
+
+    if (sInput.empty())
+    {
+        logger->error("Must specify input image");
+        return 1;
+    }
+
+    Application app(sInput, sModel, acfCalibration, minWidth, doWindow, resolution);
+    app.setLogger(logger);
+
+    aglet::GLContext::RenderDelegate delegate = [&]() {
+        return app.update();
+    };
+
+    (*app.context)(delegate);
+
+    logger->info("DONE");
+
+    return 0;
+}
+
+// :::: utility ::::
+
+static std::shared_ptr<cv::VideoCapture> create(const std::string& filename)
+{
+    if (filename.find_first_not_of("0123456789") == string::npos)
+    {
+        return std::make_shared<cv::VideoCapture>(std::stoi(filename));
+    }
+    else
+    {
+        return std::make_shared<cv::VideoCapture>(filename);
+    }
+}
+
+static cv::Size getSize(cv::VideoCapture& video)
+{
+    return {
+        static_cast<int>(video.get(CV_CAP_PROP_FRAME_WIDTH)),
+        static_cast<int>(video.get(CV_CAP_PROP_FRAME_HEIGHT))
+    };
+}

--- a/src/app/pipeline/pipeline.cpp
+++ b/src/app/pipeline/pipeline.cpp
@@ -57,9 +57,13 @@
 
 */
 
-#include "GPUDetectionPipeline.h"
+#if defined(ACF_ADD_TO_STRING)
+#  include <io/stdlib_string.h> // first
+#endif
 
 #include <util/Logger.h>
+
+#include "GPUDetectionPipeline.h"
 
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>

--- a/src/app/pipeline/plist.in
+++ b/src/app/pipeline/plist.in
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE
+    plist
+    PUBLIC
+    "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd"
+>
+<plist version="1.0">
+<dict>
+  <!--
+  String below icon (XCODE_ATTRIBUTE_PRODUCT_NAME)
+  -->
+  <key>CFBundleDisplayName</key>
+  <string>$(PRODUCT_NAME)</string>
+
+  <!--
+  Internal name of executable file
+  e.g.: ProductName.app/ExecutableName
+  NOTE: This key is required (!)
+  Initialized automatically by Xcode (no need to modify cmake target property)
+  (XCODE_ATTRIBUTE_EXECUTABLE_NAME)
+  -->
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+
+  <!--
+  Bundle identifier. Unique id, usually reverse DNS:
+  e.g.: com.example.johndoe.awesomeproject
+  (XCODE_ATTRIBUTE_BUNDLE_IDENTIFIER)
+  -->
+  <key>CFBundleIdentifier</key>
+  <string>$(BUNDLE_IDENTIFIER)</string>
+
+  <!--
+  Storyboards
+  -->
+  <key>UILaunchStoryboardName</key>
+  <string>LaunchScreen</string>
+
+  <!--
+  Device supported orientations
+  -->
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <!--
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+    -->
+  </array>
+  <key>UISupportedInterfaceOrientations~ipad</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <!--
+    <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+    -->
+  </array>
+
+  <!--
+  Other
+  -->
+  <key>UIFileSharingEnabled</key>
+  <string>YES</string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.1</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>1.1</string>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>UIRequiredDeviceCapabilities</key>
+  <array>
+    <string>armv7</string>
+  </array>
+  <key>NSCameraUsageDescription</key>
+  <string>CAMERA</string>  
+</dict>
+</plist>


### PR DESCRIPTION
Add a simple console application that makes use of acf::GPUACF to precompute ACF pyramids on the GPU and retrieve them (with latency) for fast CPU based object detection.  The GPUDetectionPipeline class is added to provide the required scheduling and to add the threading required to hide the new GPU->CPU texture overhead in two frame times of latency.

The code is adapted from the drishti::hci::FaceFinder::runFast() method and related routines, see https://github.com/elucideye/drishti/blob/f5742c5cc737f550e57f5cb832c2ffccfe08123d/src/lib/drishti/hci/FaceFinder.cpp#L435-L523
