### PR TITLE
automate pipeline test/benchmark w/ gauze

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ if(ACF_USE_DRISHTI_UPLOAD)
   )
   endif()    
 else()
-  set(ACF_HUNTER_GATE_URL "https://github.com/ruslo/hunter/archive/v0.20.28.tar.gz")
-  set(ACF_HUNTER_GATE_SHA1 "8fee57e4232e35e28a88f0beafb5f2a739a3fa3c")
+  set(ACF_HUNTER_GATE_URL "https://github.com/ruslo/hunter/archive/v0.20.51.tar.gz")
+  set(ACF_HUNTER_GATE_SHA1 "4919c28709340b4fb64a6c11d0bc203301edd685")
   if(HUNTER_ENABLED AND NOT ACF_IS_REPO_BUILD)
     # DEPENDENCY: if(HUNTER_ENABLE): we are being used as a dependency from
     # another project and we will use the config.cmake from the parent project.
@@ -118,6 +118,7 @@ option(ACF_SERIALIZE_WITH_CVMATIO "Build with CVMATIO" ON)
 option(ACF_BUILD_OGLES_GPGPU "Build with OGLES_GPGPU" ON)
 option(ACF_BUILD_TESTS "Build tests" OFF)
 option(ACF_BUILD_EXAMPLES "Build examples" ON)
+option(ACF_OPENGL_ES3 "Use OpenGL ES 3.0 (and compatible)" OFF)
 
 ####################
 ## Version check ###

--- a/bin/travis_build.sh
+++ b/bin/travis_build.sh
@@ -34,6 +34,7 @@ polly_args=(
     --archive acf
     --jobs 2
     --test
+    --verbose
     ${INSTALL}
 )
 

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,4 +1,4 @@
-if(IOS)
+if(IOS OR ANDROID)
   # local workaround for protobuf compiler crash with Xcode 8.1
   # see https://github.com/elucideye/acf/issues/41
   set(opencv_cmake_args
@@ -6,6 +6,18 @@ if(IOS)
     BUILD_PROTOBUF=OFF
     BUILD_LIBPROTOBUF_FROM_SOURCES=NO
     BUILD_opencv_dnn=OFF
-    )
-  hunter_config(OpenCV VERSION ${HUNTER_OpenCV_VERSION} CMAKE_ARGS ${opencv_cmake_args})
+     
+    WITH_JASPER=OFF
+    BUILD_JASPER=OFF
+  )
+  hunter_config(OpenCV VERSION ${HUNTER_OpenCV_VERSION} CMAKE_ARGS ${opencv_cmake_args})  
 endif()
+
+### ogles_gpgpu ###
+set(ogles_gpgpu_cmake_args
+  OGLES_GPGPU_VERBOSE=OFF
+  OGLES_GPGPU_OPENGL_ES3=${ACF_OPENGL_ES3}
+)
+hunter_config(ogles_gpgpu VERSION ${HUNTER_ogles_gpgpu_VERSION} CMAKE_ARGS ${ogles_gpgpu_cmake_args})
+
+

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -6,4 +6,6 @@ find_package(cxxopts CONFIG REQUIRED)
 
 add_subdirectory(acf)
 
-add_subdirectory(pipeline)
+if (ACF_BUILD_OGLES_GPGPU AND TARGET aglet::aglet)
+  add_subdirectory(pipeline)
+endif()

--- a/src/app/pipeline/CMakeLists.txt
+++ b/src/app/pipeline/CMakeLists.txt
@@ -58,8 +58,9 @@ gauze_add_test(
   NAME ${test_name}
   COMMAND ${test_app}
       --input=$<GAUZE_RESOURCE_FILE:${DRISHTI_FACES_FACE_IMAGE}>
-      --repeat=200
+      --repeat=64
       --model=$<GAUZE_RESOURCE_FILE:${DRISHTI_ASSETS_FACE_DETECTOR}>
       --minimum=128
       --calibration=0.01
+      --global
 )

--- a/src/app/pipeline/CMakeLists.txt
+++ b/src/app/pipeline/CMakeLists.txt
@@ -18,6 +18,10 @@ set(acf_srcs
 add_executable(${test_app} ${acf_srcs})
 target_link_libraries(${test_app} PUBLIC acf cxxopts::cxxopts ${OpenCV_LIBS})
 
+# cross platform testing
+hunter_add_package(gauze)
+find_package(gauze CONFIG REQUIRED)
+
 # thread-pool-cpp:
 hunter_add_package(thread-pool-cpp)
 find_package(thread-pool-cpp CONFIG REQUIRED)
@@ -42,4 +46,20 @@ set_target_properties(
   XCODE_ATTRIBUTE_BUNDLE_IDENTIFIER "com.elucideye.acf.${test_app}"
   XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.elucideye.acf.${test_app}"
   XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2" # iPhone/iPad
+)
+
+#############
+### TEST ####
+#############
+set(test_name AcfPipelineTest)
+message("test_app ${test_app} test_name ${test_name}")
+
+gauze_add_test(
+  NAME ${test_name}
+  COMMAND ${test_app}
+      --input=$<GAUZE_RESOURCE_FILE:${DRISHTI_FACES_FACE_IMAGE}>
+      --repeat=200
+      --model=$<GAUZE_RESOURCE_FILE:${DRISHTI_ASSETS_FACE_DETECTOR}>
+      --minimum=128
+      --calibration=0.01
 )

--- a/src/app/pipeline/GPUDetectionPipeline.cpp
+++ b/src/app/pipeline/GPUDetectionPipeline.cpp
@@ -109,8 +109,11 @@ GPUDetectionPipeline::~GPUDetectionPipeline()
 {
     try
     {
-        // If this has already been retrieved it will throw
-        impl->scene.get(); // block on any abandoned calls
+        if(impl && impl->scene.valid())
+        {
+            // If this has already been retrieved it will throw
+            impl->scene.get(); // block on any abandoned calls
+        }
     }
     catch (std::exception& e)
     {
@@ -120,6 +123,11 @@ GPUDetectionPipeline::~GPUDetectionPipeline()
 void GPUDetectionPipeline::operator+=(const DetectionCallback& callback)
 {
     impl->callbacks.push_back(callback);
+}
+
+void GPUDetectionPipeline::setDoGlobalNMS(bool flag)
+{
+    impl->doSingleObject = flag;
 }
 
 void GPUDetectionPipeline::init(const cv::Size& inputSize)

--- a/src/app/pipeline/GPUDetectionPipeline.h
+++ b/src/app/pipeline/GPUDetectionPipeline.h
@@ -51,6 +51,8 @@ public:
  
     void operator+=(const DetectionCallback& callback);
 
+    std::map<std::string, double> summary();
+
 protected:
 
     // Allow user defined object detection drawing via inheritance.

--- a/src/app/pipeline/GPUDetectionPipeline.h
+++ b/src/app/pipeline/GPUDetectionPipeline.h
@@ -52,6 +52,8 @@ public:
     void operator+=(const DetectionCallback& callback);
 
     std::map<std::string, double> summary();
+    
+    void setDoGlobalNMS(bool flag);
 
 protected:
 

--- a/src/app/pipeline/pipeline.cpp
+++ b/src/app/pipeline/pipeline.cpp
@@ -62,6 +62,7 @@
 #endif
 
 #include <util/Logger.h>
+#include <util/ScopeTimeLogger.h>
 
 #include "GPUDetectionPipeline.h"
 
@@ -91,6 +92,81 @@ void* void_ptr(const T* ptr)
 
 static std::shared_ptr<cv::VideoCapture> create(const std::string& filename);
 static cv::Size getSize(cv::VideoCapture& video);
+
+class VideoCaptureImage : public cv::VideoCapture
+{
+public:
+    VideoCaptureImage(const cv::Mat &image, int frames=100)
+        : image(image)
+        , frames(frames)
+    {
+    }
+    
+    VideoCaptureImage(const std::string &filename, int frames=100)
+        : frames(frames)
+    {
+        image = cv::imread(filename, cv::IMREAD_COLOR);
+    }
+    
+    virtual ~VideoCaptureImage()
+    {
+        
+    }
+    
+    void setRepeat(int n)
+    {
+        frames = n;
+    }
+    
+    virtual bool grab ()
+    {
+        return false;
+    }
+    
+    virtual bool isOpened () const
+    {
+        return !image.empty();
+    }
+    
+    virtual void release()
+    {
+        image.release();
+    }
+    
+    virtual bool open (const cv::String &filename)
+    {
+        image = cv::imread(filename);
+        return !image.empty();
+    }
+    virtual bool read (cv::OutputArray image)
+    {
+        if(++index <= frames)
+        {
+            image.assign(this->image);
+            return true;
+        }
+        return false;
+    }
+    
+    double get(int propId) const
+    {
+        switch (propId)
+        {
+            case CV_CAP_PROP_FRAME_WIDTH:
+                return static_cast<double>(image.cols);
+            case CV_CAP_PROP_FRAME_HEIGHT:
+                return static_cast<double>(image.rows);
+            case CV_CAP_PROP_FRAME_COUNT:
+                return static_cast<double>(frames);
+            default:
+                return 0.0;
+        }
+    }
+    
+    cv::Mat image;
+    int frames = 0;
+    int index = -1;
+};
 
 struct Application
 {
@@ -145,6 +221,14 @@ struct Application
     {
         this->logger = logger;
     }
+    
+    void setRepeat(int n)
+    {
+        if(VideoCaptureImage *cap = dynamic_cast<VideoCaptureImage *>(video.get()))
+        {
+            cap->setRepeat(n);
+        }
+    }
 
     bool update()
     {
@@ -158,10 +242,10 @@ struct Application
 
         if (frame.channels() == 3)
         {
-// ogles_gpgpu supports both {BGR,RGB}A and NV{21,12} inputs, and
-// cv::VideoCapture support {RGB,BGR} output, so we need to add an
-// alpha plane.  Doing this on the CPU is wasteful, and it would be
-// better to access the camera directly for NV{21,12} processing
+            // ogles_gpgpu supports both {BGR,RGB}A and NV{21,12} inputs, and
+            // cv::VideoCapture support {RGB,BGR} output, so we need to add an
+            // alpha plane.  Doing this on the CPU is wasteful, and it would be
+            // better to access the camera directly for NV{21,12} processing
 #if ANDROID
             cv::cvtColor(frame, frame, cv::COLOR_BGR2RGBA); // android need GL_RGBA
 #else
@@ -173,13 +257,15 @@ struct Application
 
         if (logger)
         {
-            logger->info("OBJECTS : {}", result.second.roi.size());
+            logger->info("OBJECTS[{}] = {}", counter, result.second.roi.size());
         }
 
         if (display)
         {
             show(result.first);
         }
+        
+        counter++;
 
         return true; // continue sequence
     }
@@ -203,16 +289,23 @@ struct Application
     std::shared_ptr<cv::VideoCapture> video;
     std::shared_ptr<acf::Detector> detector;
     std::shared_ptr<acf::GPUDetectionPipeline> pipeline;
+    
+    std::size_t counter = 0;
 };
 
-int main(int argc, char** argv)
+int gauze_main(int argc, char** argv)
 {
     auto logger = util::Logger::create("acf-pipeline");
+
+    for(int i = 0; i < argc; i++)
+    {
+        logger->info("arg[{}] = {}", i, argv[i]);
+    }
 
     bool help = false, doWindow = false;
     float resolution = 1.f, acfCalibration = 0.f;
     std::string sInput, sOutput, sModel;
-    int minWidth = 0;
+    int minWidth = 0, repeat = 1;
 
     const int argumentCount = argc;
     cxxopts::Options options("acf-pipeline", "GPU accelerated ACF object detection (see Piotr's toolbox)");
@@ -226,6 +319,7 @@ int main(int argc, char** argv)
         ("r,resolution", "Resolution", cxxopts::value<float>(resolution))
         ("w,window", "Window", cxxopts::value<bool>(doWindow))
         ("M,minimum", "Minimum object width", cxxopts::value<int>(minWidth))
+        ("R,repeat", "Repeat the input video R times", cxxopts::value<int>(repeat))
         ("h,help", "Help message", cxxopts::value<bool>(help))
         ;
     // clang-format on
@@ -251,14 +345,37 @@ int main(int argc, char** argv)
 
     Application app(sInput, sModel, acfCalibration, minWidth, doWindow, resolution);
     app.setLogger(logger);
+    app.setRepeat(repeat);
 
-    aglet::GLContext::RenderDelegate delegate = [&]() {
-        return app.update();
+    std::size_t count = 0;
+    aglet::GLContext::RenderDelegate delegate = [&]() -> bool
+    {
+        bool status = app.update();
+        if(status)
+        {
+            count++;
+        }
+        return status;
     };
 
-    (*app.context)(delegate);
+    double seconds = 0.0;    
+    { // Process all frames (main loop) and record the total time:
+        util::ScopeTimeLogger timer = [&](double total) { seconds = total; };
+        (*app.context)(delegate);
+    }
 
-    logger->info("DONE");
+    const double fps = (seconds > 0.0) ? static_cast<double>(count)/seconds : 0.0;
+    logger->info("ACF FULL: FPS={}", fps);
+
+    if(count > 0)
+    {
+        auto summary = app.pipeline->summary();
+        for(auto &entry : summary)
+        {
+            entry.second /= static_cast<double>(count);
+            logger->info("\tACF STAGE {} = {}", entry.first, entry.second);
+        }
+    }
 
     return 0;
 }
@@ -273,7 +390,14 @@ static std::shared_ptr<cv::VideoCapture> create(const std::string& filename)
     }
     else
     {
-        return std::make_shared<cv::VideoCapture>(filename);
+        if(filename.find(".png") != std::string::npos)
+        {
+            return std::make_shared<VideoCaptureImage>(filename);
+        }
+        else
+        {
+            return std::make_shared<cv::VideoCapture>(filename);
+        }
     }
 }
 

--- a/src/app/pipeline/pipeline.cpp
+++ b/src/app/pipeline/pipeline.cpp
@@ -230,6 +230,11 @@ struct Application
         }
     }
 
+    void setDoGlobalNMS(bool flag)
+    {
+        pipeline->setDoGlobalNMS(flag);
+    }
+
     bool update()
     {
         cv::Mat frame;
@@ -302,7 +307,7 @@ int gauze_main(int argc, char** argv)
         logger->info("arg[{}] = {}", i, argv[i]);
     }
 
-    bool help = false, doWindow = false;
+    bool help = false, doWindow = false, doGlobal = false;
     float resolution = 1.f, acfCalibration = 0.f;
     std::string sInput, sOutput, sModel;
     int minWidth = 0, repeat = 1;
@@ -317,6 +322,7 @@ int gauze_main(int argc, char** argv)
         ("m,model", "Model file", cxxopts::value<std::string>(sModel))
         ("c,calibration", "ACF calibration", cxxopts::value<float>(acfCalibration))
         ("r,resolution", "Resolution", cxxopts::value<float>(resolution))
+        ("g,global", "Globl nms", cxxopts::value<bool>(doGlobal))
         ("w,window", "Window", cxxopts::value<bool>(doWindow))
         ("M,minimum", "Minimum object width", cxxopts::value<int>(minWidth))
         ("R,repeat", "Repeat the input video R times", cxxopts::value<int>(repeat))
@@ -346,6 +352,7 @@ int gauze_main(int argc, char** argv)
     Application app(sInput, sModel, acfCalibration, minWidth, doWindow, resolution);
     app.setLogger(logger);
     app.setRepeat(repeat);
+    app.setDoGlobalNMS(doGlobal);
 
     std::size_t count = 0;
     aglet::GLContext::RenderDelegate delegate = [&]() -> bool
@@ -403,8 +410,11 @@ static std::shared_ptr<cv::VideoCapture> create(const std::string& filename)
 
 static cv::Size getSize(cv::VideoCapture& video)
 {
-    return {
+    // clang-format off
+    return
+    {
         static_cast<int>(video.get(CV_CAP_PROP_FRAME_WIDTH)),
         static_cast<int>(video.get(CV_CAP_PROP_FRAME_HEIGHT))
     };
+    // clang-format on
 }

--- a/src/lib/acf/ACF.cpp
+++ b/src/lib/acf/ACF.cpp
@@ -37,10 +37,7 @@ Detector::Detector(const std::string& filename)
     m_good = deserializeAny(filename) == 0;
 }
 
-Detector::~Detector()
-{
-    // Provide destructor for static analyzer
-}
+Detector::~Detector() = default;
 
 int Detector::initializeOpts() // Seems to be required
 {

--- a/src/lib/acf/ACFIO.cpp
+++ b/src/lib/acf/ACFIO.cpp
@@ -167,6 +167,8 @@ int Detector::deserialize(ParserNodeDetector& detector_)
 
         opts_.parse<Field<double>, decltype(opts_->winsSave)>("winsSave", opts_->winsSave);
     }
+    
+    clf.thrsU8 = clf.thrs * 255.0; // add uint8_t compatible thresholds
 
     return 0;
 }

--- a/src/lib/acf/ACFIO.cpp
+++ b/src/lib/acf/ACFIO.cpp
@@ -160,9 +160,14 @@ int Detector::deserialize(ParserNodeDetector& detector_)
         opts_.parse<Field<double>, decltype(opts_->nPerNeg)>("nPerNeg", opts_->nPerNeg);
         opts_.parse<Field<double>, decltype(opts_->nAccNeg)>("nAccNeg", opts_->nAccNeg);
 
+        try
         {
             auto&& pJitter_ = opts_.create("pJitter", opts_->pJitter);
             pJitter_.parse<Field<double>, decltype((*pJitter_)->flip)>("flip", (*pJitter_)->flip);
+        }
+        catch(...)
+        {
+            opts_->pJitter->flip.set("jitter", false, true, 0);
         }
 
         opts_.parse<Field<double>, decltype(opts_->winsSave)>("winsSave", opts_->winsSave);

--- a/src/lib/acf/toolbox/gradientMex.cpp
+++ b/src/lib/acf/toolbox/gradientMex.cpp
@@ -105,20 +105,6 @@ void grad2(float* I, float* Gx, float* Gy, int h, int w, int d)
     }
 }
 
-#if ACF_DEBUG_ACOS_TABLE
-static bool isValid(const __m128& value)
-{
-    for (int i = 0; i < 4; i++)
-    {
-        if (std::isnan(value[0]) || std::isinf(value[0]))
-        {
-            return false;
-        }
-    }
-    return true;
-}
-#endif
-
 class ACosTable
 {
 public:
@@ -142,7 +128,7 @@ public:
     };
     const int min()
     {
-        return -(n * b - 1);
+        return -(n + b - 1);
     };
 
     const static int n = 10000, b = 10;

--- a/src/lib/acf/ut/test-acf.cpp
+++ b/src/lib/acf/ut/test-acf.cpp
@@ -33,7 +33,6 @@ int gauze_main(int argc, char** argv)
     truthFilename = argv[2];
     modelFilename = argv[3];
 
-
 #if defined(ACF_SERIALIZE_WITH_CVMATIO)
     if (argc >= 7)
     {
@@ -245,8 +244,8 @@ protected:
     // State:
     // 1) Allocates acf::Detector
     // 2) Allocates ogles_gpgpu::ACF
-
-    void initGPUAndCreatePyramid(acf::Detector::Pyramid& Pgpu)
+    
+    void initGPUAndCreatePyramid(acf::Detector::Pyramid& Pgpu, ogles_gpgpu::ACF::FeatureKind kind)
     {
         m_detector = create(modelFilename);
         ASSERT_NE(m_detector, nullptr);
@@ -259,7 +258,7 @@ protected:
         static const bool doGray = false;
         ogles_gpgpu::Size2d inputSize(image.cols, image.rows);
 
-        m_acf = std::make_shared<ogles_gpgpu::ACF>(nullptr, inputSize, sizes, ogles_gpgpu::ACF::kM012345, doGray, shrink);
+        m_acf = std::make_shared<ogles_gpgpu::ACF>(nullptr, inputSize, sizes, kind, doGray, shrink);
         m_acf->setRotation(0);
         m_acf->setDoLuvTransfer(false);
 
@@ -544,23 +543,11 @@ TEST_F(ACFTest, ACFPyramidCPU)
     ASSERT_GT(pyramid->data.max_size(), 0);
 }
 
-#if defined(ACF_SERIALIZE_WITH_CVMATIO)
-TEST_F(ACFTest, ACFInriaDetector)
-{
-    testPedestrianDetector(acfInriaDetectorFilename, acfPedestrianImageFilename);
-}
-
-TEST_F(ACFTest, ACFCaltechDetector)
-{
-    testPedestrianDetector(acfCaltechDetectorFilename, acfPedestrianImageFilename);
-}
-#endif // defined(ACF_SERIALIZE_WITH_CVMATIO)
-
 #if defined(ACF_DO_GPU)
 TEST_F(ACFTest, ACFPyramidGPU10)
 {
     acf::Detector::Pyramid Pgpu;
-    initGPUAndCreatePyramid(Pgpu);
+    initGPUAndCreatePyramid(Pgpu, ogles_gpgpu::ACF::kLUVM012345);
     ASSERT_NE(m_detector, nullptr);
     ASSERT_NE(m_acf, nullptr);
 
@@ -574,7 +561,7 @@ TEST_F(ACFTest, ACFPyramidGPU10)
 TEST_F(ACFTest, ACFDetectionGPU10)
 {
     acf::Detector::Pyramid Pgpu;
-    initGPUAndCreatePyramid(Pgpu);
+    initGPUAndCreatePyramid(Pgpu, ogles_gpgpu::ACF::kLUVM012345);
     ASSERT_NE(m_detector, nullptr);
     ASSERT_NE(m_acf, nullptr);
 
@@ -585,6 +572,19 @@ TEST_F(ACFTest, ACFDetectionGPU10)
     ASSERT_GT(objects.size(), 0); // Very weak test!!!
 }
 #endif // defined(ACF_DO_GPU)
+
+#if defined(ACF_SERIALIZE_WITH_CVMATIO)
+TEST_F(ACFTest, ACFInriaDetector)
+{
+    testPedestrianDetector(acfInriaDetectorFilename, acfPedestrianImageFilename);
+}
+
+TEST_F(ACFTest, ACFCaltechDetector)
+{
+    testPedestrianDetector(acfCaltechDetectorFilename, acfPedestrianImageFilename);
+}
+#endif // defined(ACF_SERIALIZE_WITH_CVMATIO)
+
 
 // ### utility ###
 


### PR DESCRIPTION
* update hunter (latest gauze)
* add some per stage timing in GPUDetectionPipeline
* compute FPS for full pipeline process (including IO)
* add ACF_OPENGL_ES3 option to support PBO texture reads

Note: Android is currently spending much of its time in the ACF pyramid read/retrieval, unlike iOS, which uses the very efficient iOS texture cache mechanism.  The optimized GraphicBuffer mappings in ogles_gpgpu are not possible in recent Android releases since dlopen/dlsym calls to systems libs are blocked entirely.