### PR TITLE
GLSL + C preprocessor syntax fixes for MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 ###################
 
 # See https://github.com/hunter-packages/check_ci_tag when changing VERSION
-project(acf VERSION 0.1.4)
+project(acf VERSION 0.1.5)
 
 set(ACF_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ if(ACF_USE_DRISHTI_UPLOAD)
   )
   endif()    
 else()
-  set(ACF_HUNTER_GATE_URL "https://github.com/ruslo/hunter/archive/v0.20.51.tar.gz")
-  set(ACF_HUNTER_GATE_SHA1 "4919c28709340b4fb64a6c11d0bc203301edd685")
+  set(ACF_HUNTER_GATE_URL "https://github.com/ruslo/hunter/archive/v0.20.74.tar.gz")
+  set(ACF_HUNTER_GATE_SHA1 "88e3c806f0ff640c0e3cbc32b340ae2c370b31f5")
   if(HUNTER_ENABLED AND NOT ACF_IS_REPO_BUILD)
     # DEPENDENCY: if(HUNTER_ENABLE): we are being used as a dependency from
     # another project and we will use the config.cmake from the parent project.

--- a/src/lib/acf/gpu/gradhist.cpp
+++ b/src/lib/acf/gpu/gradhist.cpp
@@ -24,8 +24,9 @@ BEGIN_OGLES_GPGPU
 
 // clang-format off
 const char * GradHistProc::fshaderGradHistSrcN = 
+
 #if defined(OGLES_GPGPU_OPENGLES)
- precision highp float;
+OG_TO_STR(precision highp float;)
 #endif
 OG_TO_STR(
  varying vec2 vTexCoord;

--- a/src/lib/acf/gpu/gradhist.cpp
+++ b/src/lib/acf/gpu/gradhist.cpp
@@ -23,11 +23,11 @@ BEGIN_OGLES_GPGPU
 // [0][1][2][3]
 
 // clang-format off
-const char * GradHistProc::fshaderGradHistSrcN = OG_TO_STR
-(
+const char * GradHistProc::fshaderGradHistSrcN = 
 #if defined(OGLES_GPGPU_OPENGLES)
  precision highp float;
 #endif
+OG_TO_STR(
  varying vec2 vTexCoord;
  uniform sampler2D uInputTex;
  uniform float nOrientations;

--- a/src/lib/acf/gpu/swizzle2.cpp
+++ b/src/lib/acf/gpu/swizzle2.cpp
@@ -28,7 +28,7 @@ void MergeProc::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int posi
 // clang-format off
 const char *MergeProc::fshaderMergeSrcABC1 = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+ OG_TO_STR(precision mediump float;)
 #endif
 OG_TO_STR(
  varying vec2 textureCoordinate;
@@ -45,12 +45,11 @@ OG_TO_STR(
 // clang-format on
 
 // clang-format off
-const char *MergeProc::fshaderMergeSrcAB12 = OG_TO_STR
-(
+const char *MergeProc::fshaderMergeSrcAB12 = 
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+ OG_TO_STR(precision mediump float;)
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  uniform sampler2D inputImageTexture;
  uniform sampler2D inputImageTexture2;
@@ -67,7 +66,7 @@ const char *MergeProc::fshaderMergeSrcAB12 = OG_TO_STR
 // clang-format off
 const char *MergeProc::fshaderMergeSrcAD12 =
 #if defined(OGLES_GPGPU_OPENGLES)
- precision mediump float;
+  OG_TO_STR(precision mediump float;)
 #endif
 OG_TO_STR(
  varying vec2 textureCoordinate;

--- a/src/lib/acf/gpu/swizzle2.cpp
+++ b/src/lib/acf/gpu/swizzle2.cpp
@@ -26,12 +26,11 @@ void MergeProc::useTexture(GLuint id, GLuint useTexUnit, GLenum target, int posi
 }
 
 // clang-format off
-const char *MergeProc::fshaderMergeSrcABC1 = OG_TO_STR
-(
+const char *MergeProc::fshaderMergeSrcABC1 = 
 #if defined(OGLES_GPGPU_OPENGLES)
  precision mediump float;
 #endif
-
+OG_TO_STR(
  varying vec2 textureCoordinate;
  uniform sampler2D inputImageTexture;
  uniform sampler2D inputImageTexture2;
@@ -66,12 +65,11 @@ const char *MergeProc::fshaderMergeSrcAB12 = OG_TO_STR
 // clang-format on
 
 // clang-format off
-const char *MergeProc::fshaderMergeSrcAD12 = OG_TO_STR
-(
+const char *MergeProc::fshaderMergeSrcAD12 =
 #if defined(OGLES_GPGPU_OPENGLES)
  precision mediump float;
 #endif
- 
+OG_TO_STR(
  varying vec2 textureCoordinate;
  uniform sampler2D inputImageTexture;
  uniform sampler2D inputImageTexture2;


### PR DESCRIPTION
* update hunter for aglet w/ MSVC fix (`glewInit()`, etc)
* fix c preprocessor syntax for msvc glsl shaders