### PR TITLE
run convTri on all scales/types in all cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 ###################
 
 # See https://github.com/hunter-packages/check_ci_tag when changing VERSION
-project(acf VERSION 0.1.9)
+project(acf VERSION 0.1.10)
 
 set(ACF_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 

--- a/src/lib/acf/ACF.cpp
+++ b/src/lib/acf/ACF.cpp
@@ -256,14 +256,6 @@ int Detector::operator()(const MatP& IpTranspose, std::vector<cv::Rect>& objects
     return (*this)(P, objects, scores);
 }
 
-static std::vector<int> create_random_indices(int n)
-{
-    std::vector<int> indices(n);
-    std::iota(indices.begin(), indices.end(), 0);
-    std::random_shuffle(indices.begin(), indices.end());
-    return indices;
-}
-
 // Multiscale search:
 int Detector::operator()(const Pyramid& P, std::vector<cv::Rect>& objects, std::vector<double>* scores)
 {
@@ -623,6 +615,14 @@ void Detector::Options::merge(const Options& src, int checkExtra)
     pBoost.merge(src.pBoost, checkExtra);
     pNms.merge(src.pNms, checkExtra);
     pPyramid.merge(src.pPyramid, checkExtra);
+}
+
+std::vector<int> create_random_indices(int n)
+{
+    std::vector<int> indices(n);
+    std::iota(indices.begin(), indices.end(), 0);
+    std::random_shuffle(indices.begin(), indices.end());
+    return indices;
 }
 
 ACF_NAMESPACE_END

--- a/src/lib/acf/ACF.cpp
+++ b/src/lib/acf/ACF.cpp
@@ -14,6 +14,8 @@
 
 #include <util/IndentingOStreamBuffer.h>
 #include <util/string_hash.h>
+#include <util/Parallel.h>
+
 #include <iomanip>
 #include <numeric> // for iota
 
@@ -269,7 +271,7 @@ int Detector::operator()(const Pyramid& P, std::vector<cv::Rect>& objects, std::
     // Here we create random indices so that (on average) for each `const cv::Range &r` slice
     // in the cv::parallel_for_(const cv::Range &r, ...) call, the total ACF Pyramid area
     // for all levels (specified by Range::{start,end}) will be equal for every thread.
-    auto scales = create_random_indices(P.nScales);
+    auto scales = util::create_random_indices(P.nScales);
     std::vector<DetectionVec> bbs_(P.nScales);
 
     std::function<void(const cv::Range& r)> worker = [&](const cv::Range& r) {
@@ -615,14 +617,6 @@ void Detector::Options::merge(const Options& src, int checkExtra)
     pBoost.merge(src.pBoost, checkExtra);
     pNms.merge(src.pNms, checkExtra);
     pPyramid.merge(src.pPyramid, checkExtra);
-}
-
-std::vector<int> create_random_indices(int n)
-{
-    std::vector<int> indices(n);
-    std::iota(indices.begin(), indices.end(), 0);
-    std::random_shuffle(indices.begin(), indices.end());
-    return indices;
 }
 
 ACF_NAMESPACE_END

--- a/src/lib/acf/ACF.h
+++ b/src/lib/acf/ACF.h
@@ -660,6 +660,8 @@ inline void fuseChannels(Iterator begin, Iterator end, MatP& Ip)
     Ip.get() = stack;
 }
 
+std::vector<int> create_random_indices(int n);
+
 ACF_NAMESPACE_END
 
 void imResample(const MatP& A, MatP& B, const cv::Size& size, double nrm);

--- a/src/lib/acf/ACF.h
+++ b/src/lib/acf/ACF.h
@@ -660,8 +660,6 @@ inline void fuseChannels(Iterator begin, Iterator end, MatP& Ip)
     Ip.get() = stack;
 }
 
-std::vector<int> create_random_indices(int n);
-
 ACF_NAMESPACE_END
 
 void imResample(const MatP& A, MatP& B, const cv::Size& size, double nrm);

--- a/src/lib/acf/chnsPyramid.cpp
+++ b/src/lib/acf/chnsPyramid.cpp
@@ -360,7 +360,7 @@ int Detector::chnsPyramid(const MatP& Iin, const Options::Pyramid* pIn, Pyramid&
     // using simple uniform slicing will tend to starve some threads due to the nature of the
     // pyramid layout.  Randomizing the scale indices should do better.  More optimal strategies
     // may exist with further testing (work stealing, etc).
-    const auto scalesIndex = create_random_indices(nScales);
+    const auto scalesIndex = util::create_random_indices(nScales);
     
     auto isAIndex = isA;
     std::random_shuffle(isAIndex.begin(), isAIndex.end());

--- a/src/lib/util/Parallel.h
+++ b/src/lib/util/Parallel.h
@@ -16,6 +16,7 @@
 #include <opencv2/core/core.hpp>
 
 #include <functional>
+#include <numeric>
 
 UTIL_NAMESPACE_BEGIN
 
@@ -107,6 +108,14 @@ public:
 protected:
     std::function<void(const cv::Range& r)> m_function;
 };
+
+inline std::vector<int> create_random_indices(int n)
+{
+    std::vector<int> indices(n);
+    std::iota(indices.begin(), indices.end(), 0);
+    std::random_shuffle(indices.begin(), indices.end());
+    return indices;
+}
 
 UTIL_NAMESPACE_END
 


### PR DESCRIPTION
* issue described here https://github.com/elucideye/acf/issues/69 : convTri was skipped in cases where `isA` is empty
* use standard c++11 style opencv cv::parallel_for_ with direct lambda input (no std::function intermediate)
* use a random scale scheduler (should be better than uniform slices)