### PR TITLE
pyramid/channel fixes and minor console app updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ if(ACF_USE_DRISHTI_UPLOAD)
   )
   endif()
 else()
-  set(ACF_HUNTER_GATE_URL "https://github.com/ruslo/hunter/archive/v0.21.18.tar.gz")
-  set(ACF_HUNTER_GATE_SHA1 "19e4a2f3034baa13f215eba3aa580365c5254508")
+  set(ACF_HUNTER_GATE_URL "https://github.com/ruslo/hunter/archive/v0.21.19.tar.gz")
+  set(ACF_HUNTER_GATE_SHA1 "5ead1e069b437930d0de8a21824b20fb52b37b50")
   if(HUNTER_ENABLED AND NOT ACF_IS_REPO_BUILD)
     # DEPENDENCY: if(HUNTER_ENABLE): we are being used as a dependency from
     # another project and we will use the config.cmake from the parent project.
@@ -94,7 +94,7 @@ endif()
 ###################
 
 # See https://github.com/hunter-packages/check_ci_tag when changing VERSION
-project(acf VERSION 0.1.10)
+project(acf VERSION 0.1.11)
 
 set(ACF_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 

--- a/src/app/pipeline/GPUDetectionPipeline.cpp
+++ b/src/app/pipeline/GPUDetectionPipeline.cpp
@@ -109,10 +109,21 @@ struct GPUDetectionPipeline::Impl
     } log;
 };
 
-GPUDetectionPipeline::GPUDetectionPipeline(DetectionPtr& detector, const cv::Size& inputSize, std::size_t n, int rotation, int minObjectWidth)
+GPUDetectionPipeline::GPUDetectionPipeline
+(
+    DetectionPtr& detector,
+    const cv::Size& inputSize,
+    std::size_t n,
+    int rotation,
+    int minObjectWidth,
+    bool useLatency,
+    bool doCpuACF
+)
 {
     impl = util::make_unique<Impl>(detector);
     impl->minObjectWidth = minObjectWidth;
+    impl->doOptimizedPipeline = useLatency;
+    impl->doCpuACF = doCpuACF;
     init(inputSize);
 }
 

--- a/src/app/pipeline/GPUDetectionPipeline.h
+++ b/src/app/pipeline/GPUDetectionPipeline.h
@@ -41,7 +41,16 @@ public:
     using DetectionCallback = std::function<void(GLuint texture, const Detections& detections)>;
     using FrameInput = ogles_gpgpu::FrameInput;
 
-    GPUDetectionPipeline(DetectionPtr& detector, const cv::Size& inputSize, std::size_t n, int rotation, int minObjectWidth);
+    GPUDetectionPipeline
+    (
+        DetectionPtr& detector,
+        const cv::Size& inputSize,
+        std::size_t n,
+        int rotation,
+        int minObjectWidth,
+        bool useLatency = true,
+        bool doCpuACF = false
+    );
     virtual ~GPUDetectionPipeline();
 
     GLuint getInputTexture();

--- a/src/lib/acf/chnsCompute.cpp
+++ b/src/lib/acf/chnsCompute.cpp
@@ -136,7 +136,14 @@ ACF_NAMESPACE_BEGIN
 
 static int addChn(Detector::Channels& chns, const MatP& data, const std::string& name, const std::string& padWith, int h, int w);
 
-int Detector::chnsCompute(const MatP& IIn, const Options::Pyramid::Chns& pChnsIn, Detector::Channels& chns, bool isInit, MatLoggerType pLogger)
+int Detector::chnsCompute
+(
+    const MatP& IIn,
+    const Options::Pyramid::Chns& pChnsIn,
+    Detector::Channels& chns,
+    bool isInit,
+    MatLoggerType pLogger
+)
 {
     Options::Pyramid::Chns pChns = pChnsIn;
     if (!pChnsIn.complete.has || (pChnsIn.complete.get() != 1) || IIn.empty())
@@ -218,8 +225,8 @@ int Detector::chnsCompute(const MatP& IIn, const Options::Pyramid::Chns& pChnsIn
         // Compute color channels:
         auto p = pChns.pColor.get();
         std::string nm = "color channels";
-        rgbConvert(I, I, p.colorSpace, pChnsIn.isLuv);
-
+        rgbConvert(I, I, p.colorSpace, true, pChnsIn.isLuv);
+        
         if (I.channels())
         {
             convTri(I, I, p.smooth, 1);

--- a/src/lib/acf/rgbConvert.cpp
+++ b/src/lib/acf/rgbConvert.cpp
@@ -95,7 +95,7 @@ void rgbConvertMex(const MatP& I, MatP& J, int flag, double nrm);
 ACF_NAMESPACE_BEGIN
 
 // In general this function will support in place transformations, however, if we
-// are mapping from RGB to grayscale then we will have a channel reduction, and this
+// are mapping from RGB to grayscale then we will have a channel reduction
 int Detector::rgbConvert(const MatP& IIn, MatP& J, const std::string& colorSpace, bool useSingle, bool isLuv)
 {
     std::string cs;

--- a/src/lib/acf/toolbox/imResampleMex.cpp
+++ b/src/lib/acf/toolbox/imResampleMex.cpp
@@ -415,7 +415,7 @@ void imResample(const MatP& A, MatP& B, const cv::Size& size, double nrm)
             break;
         }
         default:
-            CV_Error(-1, "Unsupported types");
+            throw std::runtime_error("imResample: Unsupported types");
     }
 }
 


### PR DESCRIPTION
* bump patch version to v0.1.11
* refactor acf-pyramid test app: add load_as_float to handle grayscale, bgr, and bgra input types.

* acf-pipeline updates: add “—simple” and “—cpu” command line options
    + “—simple” : enable zero-latency processing
    + “—cpu” : enabels cpu pyramid construction (mostly for comparison and testing)
    + some refactoring to break longer lines

* chnsPyramid.cpp updates
  + replicate matlab grayscale->rgb handling
  + fix `is` indices — the base-one matlabe indexing had to be replaced with i-1 for the base-zero c++ adaptation
  + add `CV_Assert(!std::isnan(f0[j]))` and for `f1`
  + remove comment, reformat member function definition
  + drop redundant conditional

```
 NOTE: Here we replicate the original Matlab behavior of repeating the grayscale in 3 channels and then converting that to grayscale later treating it as a color image, even though this will produce a different single channel image in rgbConvert()

I=I(:,:,[1 1 1]); warning('Converting image to color');
```

* chnsCompute.cpp
  + fix `rgbConvert()` call — third argument should indicate single precision
  + reformat method definition