### PR TITLE
add optimized/separate triangle filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 # OSX/Linux (https://github.com/travis-ci-tester/toolchain-table)
 
-# Workaround for https://github.com/travis-ci/travis-ci/issues/8363
 language:
-  - minimal
+  - cpp
 
 # Container-based infrastructure (Linux)
 # * https://docs.travis-ci.com/user/migrating-from-legacy/#How-can-I-use-container-based-infrastructure%3F
@@ -14,86 +13,107 @@ dist:
 
 # Install packages differs for container-based infrastructure
 # * https://docs.travis-ci.com/user/migrating-from-legacy/#How-do-I-install-APT-sources-and-packages%3F
+# List of available packages:
+# * https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-trusty
+# List of available sources:
+# * https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
     packages:
-      # For Qt
-      - libegl1-mesa-dev
-
       # For ogles_gpgpu (GL library)
       - libgl1-mesa-dev
 
-      # Packages for Android development: http://superuser.com/a/360398/252568
-      - libncurses5:i386
-      - libstdc++6:i386
-      - zlib1g:i386
-
-      # Default GCC 4.8 is buggy:
-      # * https://github.com/elucideye/drishti/issues/273#issuecomment-301297286
+      # GCC 5
       - g++-5
-      - gcc-5
-
-      - clang-5.0
-      - libc++-dev
-      - libc++abi-dev
-      - libclang-5.0-dev
-      - libclang-common-5.0-dev
-      - libclang1-5.0
 
       # pip3
       - python3-pip
+
+env:
+  global:
+    - secure: "copxh/FOt+cC3TohV8GLrqmxJl/C45uNHt0hbY6E4GAw2yo4AAO5lPpGv2f/9lvxpHFv/n/mZu5MmlJwn5nJrDAb3K6r7pC5jFR0o8MFfUu+dfCm6tR0tWzFPuTuQTjnMl4wmM+t72KI7NHk0HvHm51tlR6J8Vz+OGIvt9vVHBAQtWFs9CbdiGl/HT+kjzw97xpYvbNImDsEOTYBMJExTmx+8s3MmhOyUDmbJO1x5XRF1C9CX2RALBwJbNz0oOI8FFChmtzUKzErvy5JWy8zvwWq/oQKl42RFi9GRLFM5+3NdHP8gXARykJp32cdBdtR1Sih6ySGOjrtT2go/y/asj7r2eXqewKLPsnbddeoovl098kATy/e3A1F9qZSGGMDtrW1xTaRG77KdbSXrQvnXKB58IjpDU5gCwwVFs2hbldjwsFsgcQ4w/RAHhvQrYy7S0lcqa+OjXjeYLn9DNjrZNm89Q99XbGFKCAitEcAfvG1IPsWvl4518bjBE7qwK4sUG7GFstFCGmTzy7ZhBz9vBTe7/SKu/8fYMOVmhX77rLFazZGcc6cOzoTIGdMWU2narwjAuzN7c3NzchcUtC13/+MhWgr/TLMqWJmhPHmwLMt6xrqM+DfEQzv1RFbH1t5WSnfa1L3DKgC2SW84lmL5cQScZ/qvsJC2xEpIrp49xQ="      
 
 matrix:
   include:
     # Linux {
 
     - os: linux
-      env: CONFIG=Release TOOLCHAIN=libcxx-fpic-hid-sections INSTALL=--strip
+      env: >
+        TOOLCHAIN=clang-fpic-hid-sections
+        CONFIG=Release
+        INSTALL=--strip
+        TEST=--test
+        GPU=OFF
+        BUILD_SHARED=ON
+        
+    - os: linux
+      env: >
+        TOOLCHAIN=gcc-5-pic-hid-sections-lto
+        CONFIG=Release
+        INSTALL=--strip
+        TEST=--test
+        GPU=OFF
+        BUILD_SHARED=ON
 
     - os: linux
-      env: CONFIG=Release TOOLCHAIN=gcc-5-pic-hid-sections-lto INSTALL=--strip
+      env: >
+        TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
+        CONFIG=Release
+        INSTALL=--strip
+        TEST=--test
+        GPU=OFF
+        BUILD_SHARED=OFF
 
     # }
 
     # OSX {
 
     - os: osx
-      osx_image: xcode8.3
-      env: CONFIG=Release TOOLCHAIN=osx-10-12-hid-sections INSTALL=--install
+      osx_image: xcode9.3
+      env: >
+        TOOLCHAIN=osx-10-13
+        CONFIG=Release
+        INSTALL=--install
+        TEST=--test
+        GPU=OFF
+        BUILD_SHARED=ON
 
     - os: osx
       osx_image: xcode8.3
-      env: CONFIG=MinSizeRel TOOLCHAIN=ios-nocodesign-10-3-arm64-dep-9-0-device-libcxx-hid-sections INSTALL=--install
+      env: >
+        TOOLCHAIN=ios-nocodesign-10-3-arm64-dep-9-0-device-libcxx-hid-sections
+        CONFIG=MinSizeRel
+        INSTALL=--install
+        TEST=""
+        GPU=OFF
+        BUILD_SHARED=ON
 
     - os: osx
       osx_image: xcode8.3
-      env: CONFIG=Release TOOLCHAIN=osx-10-12-sanitize-address-hid-sections INSTALL=--install
+      env: >
+        TOOLCHAIN=osx-10-12-sanitize-address-hid-sections
+        CONFIG=Release
+        INSTALL=--install
+        TEST=--test
+        GPU=OFF
+        BUILD_SHARED=ON
 
     - os: osx
-      env: CONFIG=MinSizeRel TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon-hid-sections INSTALL=--strip
+      env: >
+        TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon-hid-sections
+        CONFIG=MinSizeRel
+        INSTALL=--strip
+        TEST=--test
+        GPU=ON
+        BUILD_SHARED=OFF
 
     # }
-
-env:
-  global:
-    - secure: "copxh/FOt+cC3TohV8GLrqmxJl/C45uNHt0hbY6E4GAw2yo4AAO5lPpGv2f/9lvxpHFv/n/mZu5MmlJwn5nJrDAb3K6r7pC5jFR0o8MFfUu+dfCm6tR0tWzFPuTuQTjnMl4wmM+t72KI7NHk0HvHm51tlR6J8Vz+OGIvt9vVHBAQtWFs9CbdiGl/HT+kjzw97xpYvbNImDsEOTYBMJExTmx+8s3MmhOyUDmbJO1x5XRF1C9CX2RALBwJbNz0oOI8FFChmtzUKzErvy5JWy8zvwWq/oQKl42RFi9GRLFM5+3NdHP8gXARykJp32cdBdtR1Sih6ySGOjrtT2go/y/asj7r2eXqewKLPsnbddeoovl098kATy/e3A1F9qZSGGMDtrW1xTaRG77KdbSXrQvnXKB58IjpDU5gCwwVFs2hbldjwsFsgcQ4w/RAHhvQrYy7S0lcqa+OjXjeYLn9DNjrZNm89Q99XbGFKCAitEcAfvG1IPsWvl4518bjBE7qwK4sUG7GFstFCGmTzy7ZhBz9vBTe7/SKu/8fYMOVmhX77rLFazZGcc6cOzoTIGdMWU2narwjAuzN7c3NzchcUtC13/+MhWgr/TLMqWJmhPHmwLMt6xrqM+DfEQzv1RFbH1t5WSnfa1L3DKgC2SW84lmL5cQScZ/qvsJC2xEpIrp49xQ="
 
 # disable the default submodule logic to support local modification of .gitmodules paths
 git:
   submodules: false
-
-# See https://docs.travis-ci.com/user/private-dependencies/#API-Token
-# CI_USER_TOKEN is added to .travis.yml settings
-before_install:
-
-  # Add '--quiet' to avoid leaking the token to logs
-  - git submodule update --init --recursive --quiet
-
-  # https://stackoverflow.com/a/38790045
-  - bin/travis_clang_links.sh
 
 install:
   - source bin/hunter_env.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 ###################
 
 # See https://github.com/hunter-packages/check_ci_tag when changing VERSION
-project(acf VERSION 0.1.11)
+project(acf VERSION 0.1.12)
 
 set(ACF_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
@@ -102,6 +102,15 @@ if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
   set(CMAKE_POLICY_DEFAULT_CMP0069 NEW) # for 3rd parties added by add_subdirectory
   cmake_policy(SET CMP0069 NEW)
 endif()
+
+### RPATH ###
+if (APPLE)
+  set(ACF_ORIGIN "@loader_path")
+else()
+  set(ACF_ORIGIN "$ORIGIN")
+endif()
+set(CMAKE_INSTALL_RPATH "${ACF_ORIGIN}/../lib" "${ACF_ORIGIN}")
+
 
 string(COMPARE EQUAL "${CMAKE_SYSTEM_NAME}" "Linux" is_linux)
 
@@ -154,29 +163,11 @@ endif()
 #### Testing ###
 ################
 
-string(COMPARE EQUAL "$ENV{TRAVIS}" "true" travis_ci)
-string(COMPARE EQUAL "$ENV{APPVEYOR}" "True" appveyor_ci)
-if(travis_ci OR appveyor_ci)
-  set(ACF_CI TRUE)
-else()
-  set(ACF_CI FALSE)
-endif()
-
-# On CI platforms we won't have a usable GPU except for the Android emulator
-# We set a variable here to help us make decisions about dependencies later on.
-if(ANDROID OR NOT ${ACF_CI})
-  set(ACF_HAS_GPU TRUE)
-else()
-  set(ACF_HAS_GPU FALSE)
-endif()
+option(ACF_HAS_GPU "Drishti has GPU" ON)
 
 if(ACF_BUILD_TESTS)
-  if(IOS AND ACF_CI)
-    # do not run test on CI (TODO: remote device testing)
-  else()
-    enable_testing()
-  endif()
-
+  enable_testing()
+  
   hunter_add_package(gauze)
   find_package(gauze CONFIG REQUIRED)
 
@@ -214,17 +205,7 @@ endif()
 if(ACF_SERIALIZE_WITH_CEREAL)
   #### std::to_string ####
   try_compile(ACF_HAVE_TO_STRING "${CMAKE_BINARY_DIR}/compile_tests" "${PROJECT_SOURCE_DIR}/cmake/to_string.cpp")
-  if(ACF_HAVE_TO_STRING)
-    set(ACF_ADD_TO_STRING OFF)
-  else()
-    set(ACF_ADD_TO_STRING ON)
-  endif()
-else(ACF_USE_CEREAL)
-  # This is never needed when CEREAL extensions are disabled
-  set(ACF_ADD_TO_STRING OFF)
 endif(ACF_SERIALIZE_WITH_CEREAL)
-
-message("ACF_ADD_TO_STRING : ${ACF_ADD_TO_STRING}")
 
 ################
 ## TEST DATA ###

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,61 +7,29 @@ environment:
 
   matrix:
 
-    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      TOOLCHAIN: "vs-15-2017"
       CONFIG: Release
+      BUILD_SHARED: ON
 
     - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-      CONFIG: Debug
+      CONFIG: Release
+      BUILD_SHARED: OFF
 
     - TOOLCHAIN: "vs-14-2015-win64-sdk-8-1"
       CONFIG: Release
+      BUILD_SHARED: OFF      
 
     - TOOLCHAIN: "vs-14-2015-win64-sdk-8-1"
       CONFIG: Debug
+      BUILD_SHARED: OFF
 
 install:
-  # Python 3
-  - cmd: set PATH=C:\Python34-x64;C:\Python34-x64\Scripts;%PATH%
-
-  # Install Python package 'requests'
-  - cmd: pip install requests
-  - cmd: pip install gitpython
-
-  # Install latest Polly toolchains and scripts
-  - cmd: appveyor DownloadFile https://github.com/ruslo/polly/archive/master.zip
-  - cmd: 7z x master.zip
-  - cmd: set POLLY_ROOT=%cd%\polly-master
-
-  # Install dependencies (CMake, Ninja)
-  - cmd: python %POLLY_ROOT%\bin\install-ci-dependencies.py
-
-  # Tune locations
-  - cmd: set PATH=%cd%\_ci\cmake\bin;%PATH%
-  - cmd: set PATH=%cd%\_ci\ninja;%PATH%
-
-  # Add '--quiet' to avoid leaking the token to logs
-  - cmd: git submodule update --init --recursive --quiet
-
-  # Remove entry with sh.exe from PATH to fix error with MinGW toolchain
-  # (For MinGW make to work correctly sh.exe must NOT be in your path)
-  # * http://stackoverflow.com/a/3870338/2288008
-  - cmd: set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
-
-  # Save git.exe in HUNTER_GIT_EXECUTABLE for upload
-  # * https://docs.hunter.sh/en/latest/reference/user-variables.html#hunter-git-executable
-  # Variable will be used in CMake so it's okay to use Unix style '/'
-  - cmd: set HUNTER_GIT_EXECUTABLE=C:/Program Files/Git/bin/git.exe
-
-  # Use MinGW from Qt tools because version is higher
-  # * http://www.appveyor.com/docs/installed-software#qt
-  - cmd: set MINGW_PATH=C:\Qt\Tools\mingw492_32\bin
-
-  # MSYS2 location
-  - cmd: set MSYS_PATH=C:\msys64\usr\bin
+  - cmd: bin\hunter_env.cmd
 
 build_script:
-
-  - cmd: bin\build-appveyor.cmd "%CONFIG%" "%TOOLCHAIN%"
+  - cmd: set APPVEYOR_CMAKE_ARGS=ACF_HAS_GPU=OFF
+  - cmd: bin\build-appveyor.cmd "%CONFIG%" "%TOOLCHAIN%" "%BUILD_SHARED%"
 
 artifacts:
   - path: _archives\acf-*.tar.gz

--- a/bin/build-appveyor.cmd
+++ b/bin/build-appveyor.cmd
@@ -1,6 +1,6 @@
 :: Name: build-appveyor.cmd
 :: Purpose: Support readable multi-line polly.py build commands
-:: Copyright 2016-2017 Elucideye, Inc.
+:: Copyright 2016-2018 Elucideye, Inc.
 ::
 :: Multi-line commands are not currently supported directly in appveyor.yml files
 ::
@@ -15,7 +15,8 @@ python %POLLY_ROOT%\bin\polly.py ^
 --toolchain "%2%" ^
 --test ^
 --fwd ^
+ACF_USE_DRISHTI_UPLOAD=YES ^
+ACF_BUILD_SHARED_SDK="%3" ^
 ACF_COPY_3RDPARTY_LICENSES=ON ^
 ACF_BUILD_TESTS=ON ^
-ACF_BUILD_EXAMPLES=ON ^
-ACF_USE_DRISHTI_UPLOAD=ON
+ACF_BUILD_EXAMPLES=ON %APPVEYOR_CMAKE_ARGS%

--- a/bin/hunter_env.cmd
+++ b/bin/hunter_env.cmd
@@ -1,6 +1,6 @@
 :: Name: hunter_env.cmd
 :: Purpose: Polly + cmake installation for hunter development
-:: Copyright 2017 Elucideye, Inc.
+:: Copyright 2017-2018 Elucideye, Inc.
 ::
 :: Source: https://github.com/ingenue/hunter/blob/pkg.template/appveyor.yml
 
@@ -9,6 +9,7 @@ set PATH=C:\Python34-x64;C:\Python34-x64\Scripts;%PATH%
 
 :: Install Python package 'requests'
 pip install requests
+pip install gitpython
 
 :: Install latest Polly toolchains and scripts
 appveyor DownloadFile https://github.com/ruslo/polly/archive/master.zip
@@ -29,6 +30,11 @@ git submodule update --init --recursive --quiet
 :: (For MinGW make to work correctly sh.exe must NOT be in your path)
 :: * http://stackoverflow.com/a/3870338/2288008
 set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+
+:: Save git.exe in HUNTER_GIT_EXECUTABLE for upload
+:: * https://docs.hunter.sh/en/latest/reference/user-variables.html#hunter-git-executable
+:: Variable will be used in CMake so it's okay to use Unix style '/'
+- cmd: set HUNTER_GIT_EXECUTABLE=C:/Program Files/Git/bin/git.exe
 
 :: Use MinGW from Qt tools because version is higher
 :: * http://www.appveyor.com/docs/installed-software#qt

--- a/bin/hunter_env.sh
+++ b/bin/hunter_env.sh
@@ -38,23 +38,17 @@ git submodule update --init --recursive --quiet
 # Info about OS
 uname -a
 
-# Info about available disk space
-df -h $HOME
-
-# Disable autoupdate
-# * https://github.com/Homebrew/brew/blob/7d31a70373edae4d8e78d91a4cbc05324bebc3ba/Library/Homebrew/manpages/brew.1.md.erb#L202
-export HOMEBREW_NO_AUTO_UPDATE=1
-
 # Install Python 3
-if [[ "`uname`" == "Darwin" ]]; then travis_retry brew upgrade python; fi
-if [[ "`uname`" == "Darwin" ]]; then travis_retry brew install python3; fi
+# >> Error: python 2.7.14 is already installed \n To upgrade to 3.6.4_3, run `brew upgrade python`
+# if [[ "$(uname)" == "Darwin" ]] && [ ! $(which python3) ]; then travis_retry brew install python3; fi
+if [[ "$(uname)" == "Darwin" ]] && [ ! $(which python3) ]; then travis_retry brew upgrade python; fi
 
 # Install Python package 'requests'
 # 'easy_install3' is not installed by 'brew install python3' on OS X 10.9 Maverick
-if [[ "`uname`" == "Darwin" ]]; then pip3 install requests; fi
-if [[ "`uname`" == "Darwin" ]]; then pip3 install gitpython; fi
-if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user requests; fi
-if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user gitpython; fi
+if [[ "$(uname)" == "Darwin" ]]; then pip3 install requests; fi
+if [[ "$(uname)" == "Darwin" ]]; then pip3 install gitpython; fi
+if [[ "$(uname)" == "Linux" ]]; then travis_retry pip3 install --user requests; fi
+if [[ "$(uname)" == "Linux" ]]; then travis_retry pip3 install --user gitpython; fi
 
 # Install latest Polly toolchains and scripts
 wget https://github.com/ruslo/polly/archive/master.zip
@@ -62,15 +56,19 @@ unzip -o master.zip
 POLLY_ROOT="${PWD}/polly-master"
 export PATH="${POLLY_ROOT}/bin:${PATH}"
 
-# Install dependencies (CMake, Android NDK)
-install-ci-dependencies.py
-
-# Tune locations
-export PATH="${PWD}/_ci/cmake/bin:${PATH}"
-
 # Installed if toolchain is Android (otherwise directory doesn't exist)
 export ANDROID_NDK_r10e="${PWD}/_ci/android-ndk-r10e"
 export ANDROID_NDK_r11c="${PWD}/_ci/android-ndk-r11c"
 export ANDROID_NDK_r15c="${PWD}/_ci/android-ndk-r15c"
 export ANDROID_NDK_r16b="${PWD}/_ci/android-ndk-r16b"
 export ANDROID_NDK_r17="${PWD}/_ci/android-ndk-r17"
+
+# Install dependencies (CMake, Android NDK)
+if [[ ${TRAVIS} == "true" ]]; then
+    install-ci-dependencies.py --prune-archives
+else
+    install-ci-dependencies.py
+fi
+
+# Tune locations
+export PATH="${PWD}/_ci/cmake/bin:${PATH}"

--- a/bin/travis_build.sh
+++ b/bin/travis_build.sh
@@ -17,25 +17,40 @@ TOOLCHAIN="${1}"
 CONFIG="${2}"
 INSTALL="${3}"
 
+if [[ $(uname) == "Linux" ]]; then
+    GAUZE_ANDROID_EMULATOR_GPU=swiftshader
+else
+    GAUZE_ANDROID_EMULATOR_GPU=host
+fi
+
+if [[ ${TRAVIS} == "true" ]]; then
+    GAUZE_ANDROID_USE_EMULATOR=YES # remote test w/ emulator
+else
+    GAUZE_ANDROID_USE_EMULATOR=NO # support local host testing on a real device
+fi
+
 # '--ios-{multiarch,combined}' do nothing for non-iOS builds
 polly_args=(
-    --toolchain ${TOOLCHAIN}
-    --config ${CONFIG}
+    --toolchain "${TOOLCHAIN}"
+    --config "${CONFIG}"
     --verbose
     --ios-multiarch --ios-combined
+    --archive acf
+    --jobs 2
+    "${TEST}"
+    "${INSTALL}"
     --fwd
+    ACF_USE_DRISHTI_UPLOAD=YES
+    ACF_BUILD_SHARED_SDK=${BUILD_SHARED}
     ACF_BUILD_TESTS=YES
     ACF_BUILD_EXAMPLES=YES
     ACF_COPY_3RDPARTY_LICENSES=ON
-    ACF_USE_DRISHTI_UPLOAD=ON
-    GAUZE_ANDROID_USE_EMULATOR=YES
+    ACF_HAS_GPU=${GPU}
+    GAUZE_ANDROID_USE_EMULATOR=${GAUZE_ANDROID_USE_EMULATOR}
+    GAUZE_ANDROID_EMULATOR_GPU=${GAUZE_ANDROID_EMULATOR_GPU}
+    GAUZE_ANDROID_EMULATOR_PARTITION_SIZE=40
     HUNTER_CONFIGURATION_TYPES=${CONFIG}
     HUNTER_SUPPRESS_LIST_OF_FILES=ON
-    --archive acf
-    --jobs 2
-    --test
-    --verbose
-    ${INSTALL}
 )
 
 polly.py ${polly_args[@]} --reconfig

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND ACF_SDK_3RDPARTY_PKG_LIBS_ sse2neon::sse2neon) # Add library
 # Note: Android emulator supports GPU use
 
 if((ACF_BUILD_TESTS OR ACF_BUILD_EXAMPLES) AND ACF_HAS_GPU AND ACF_BUILD_OGLES_GPGPU)
-  hunter_add_package(aglet) # aglet_FOUND will bed used in test/exe targets
+  hunter_add_package(aglet) # if(TARGET aglet::aglet) will bed used in test/exe targets
   find_package(aglet CONFIG REQUIRED)
 endif()
 

--- a/src/app/acf/CMakeLists.txt
+++ b/src/app/acf/CMakeLists.txt
@@ -17,7 +17,7 @@ if(${ACF_DO_GPU})
 endif()
 
 add_executable(${test_app} ${acf_srcs})
-target_link_libraries(${test_app} PUBLIC acf cxxopts::cxxopts)
+target_link_libraries(${test_app} PUBLIC acf acf_util cxxopts::cxxopts)
 
 if(${ACF_DO_GPU})
   target_include_directories(${test_app} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../>")
@@ -46,7 +46,7 @@ set(conv_app acf-mat2cpb)
 
 if(ACF_SERIALIZE_WITH_CVMATIO)
   add_executable(${conv_app} mat2cpb.cpp)
-  target_link_libraries(${conv_app} PUBLIC acf cxxopts::cxxopts cereal::cereal)
+  target_link_libraries(${conv_app} PUBLIC acf acf_util cxxopts::cxxopts cereal::cereal)
   set_property(TARGET ${conv_app} PROPERTY FOLDER "app/console")
   install(TARGETS ${conv_app} DESTINATION bin)
 endif()

--- a/src/app/acf/GLDetector.cpp
+++ b/src/app/acf/GLDetector.cpp
@@ -44,6 +44,7 @@ GLDetector::GLDetector(const std::string& filename, int maxSize)
     // Iniialize the OpenGL context:
     m_impl->context = aglet::GLContext::create(aglet::GLContext::kAuto);
     CV_Assert(m_impl->context && (*m_impl->context));
+    ogles_gpgpu::ACF::updateGL();
 
     // Safeguard for FBO allocation failures here:
     m_impl->maxTextureSize = maxSize;

--- a/src/app/pipeline/CMakeLists.txt
+++ b/src/app/pipeline/CMakeLists.txt
@@ -19,7 +19,7 @@ set(acf_srcs
 )
 
 add_executable(${test_app} ${acf_srcs})
-target_link_libraries(${test_app} PUBLIC acf cxxopts::cxxopts ${OpenCV_LIBS})
+target_link_libraries(${test_app} PUBLIC acf acf_util cxxopts::cxxopts ${OpenCV_LIBS})
 
 # cross platform testing
 hunter_add_package(gauze)
@@ -51,9 +51,18 @@ gauze_add_test(
   NAME ${test_name}
   COMMAND ${test_app}
       --input=$<GAUZE_RESOURCE_FILE:${DRISHTI_FACES_FACE_IMAGE}>
-      --repeat=600
+      --repeat=5
       --model=$<GAUZE_RESOURCE_FILE:${DRISHTI_ASSETS_FACE_DETECTOR}>
       --minimum=128
       --calibration=0.01
       --global
 )
+
+if(WIN32 OR CYGWIN)
+  set_property(
+    TEST ${test_name}
+    PROPERTY
+    ENVIRONMENT
+    "PATH=$<TARGET_FILE_DIR:acf>;$ENV{PATH}"
+   )
+endif()

--- a/src/app/pipeline/pipeline.cpp
+++ b/src/app/pipeline/pipeline.cpp
@@ -143,7 +143,9 @@ struct Application
             window ? "acf" : "",
             size.width,
             size.height
-        );
+        ); 
+
+        ogles_gpgpu::ACF::updateGL();
 
         // Create an object detector:
         detector = std::make_shared<acf::Detector>(model);

--- a/src/app/pyramid/CMakeLists.txt
+++ b/src/app/pyramid/CMakeLists.txt
@@ -5,6 +5,6 @@ set(test_app acf-pyramid)
 ###############
 
 add_executable(${test_app} pyramid.cpp)
-target_link_libraries(${test_app} PUBLIC acf cxxopts::cxxopts cereal::cereal)
+target_link_libraries(${test_app} PUBLIC acf acf_util cxxopts::cxxopts cereal::cereal)
 set_property(TARGET ${test_app} PROPERTY FOLDER "app/console")
 install(TARGETS ${test_app} DESTINATION bin)

--- a/src/app/pyramid/pyramid.cpp
+++ b/src/app/pyramid/pyramid.cpp
@@ -20,26 +20,26 @@
 #include <string>
 #include <iomanip>
 
-static cv::Mat load_as_float(const std::string &filename)
+static cv::Mat load_as_float(const std::string& filename)
 {
     cv::Mat I8u = cv::imread(filename, cv::IMREAD_ANYCOLOR), I32f;
-    
-    if(I8u.empty())
+
+    if (I8u.empty())
     {
         throw std::runtime_error("load_as_float: empty input");
     }
 
-    switch(I8u.channels())
+    switch (I8u.channels())
     {
         case 4:
-            cv::cvtColor(I8u, I8u, cv::COLOR_BGRA2RGB); // toolbox expects RGB
-            I8u.convertTo(I32f, CV_32FC3, 1.0f/255.0f);   // ... and CV_32FC3
+            cv::cvtColor(I8u, I8u, cv::COLOR_BGRA2RGB);   // toolbox expects RGB
+            I8u.convertTo(I32f, CV_32FC3, 1.0f / 255.0f); // ... and CV_32FC3
         case 3:
-            cv::cvtColor(I8u, I8u, cv::COLOR_BGR2RGB); // toolbox expects RGB
-            I8u.convertTo(I32f, CV_32FC3, 1.0f/255.0f);  // ... and CV_32FC3
+            cv::cvtColor(I8u, I8u, cv::COLOR_BGR2RGB);    // toolbox expects RGB
+            I8u.convertTo(I32f, CV_32FC3, 1.0f / 255.0f); // ... and CV_32FC3
             break;
         case 1:
-            I8u.convertTo(I32f, CV_32FC1, 1.0f/255.0f); // allow grayscale input
+            I8u.convertTo(I32f, CV_32FC1, 1.0f / 255.0f); // allow grayscale input
             break;
         default:
             throw std::runtime_error("load_as_float: unsupported channels");
@@ -89,36 +89,36 @@ int gauze_main(int argc, char** argv)
     }
 
     std::string base = sOutput + "/" + util::basename(sInput);
-    
+
     acf::Detector acf;
     acf::Detector::Pyramid pyramid;
-    acf.chnsPyramid({}, nullptr, pyramid, true, {});  // get defaults, i.e.: pPyramid=chnsPyramid();
-    
+    acf.chnsPyramid({}, nullptr, pyramid, true, {}); // get defaults, i.e.: pPyramid=chnsPyramid();
+
     cv::Mat I32f = load_as_float(sInput);
-    
+
     // Create a TRANSPOSE + planar format image for compatibility with the
     // original MATLAB (column major) SIMD code.
     MatP Ip(I32f.t());
-    
+
     // Request grayscale colorspace using the following:
     //pyramid.pPyramid.pChns->pColor->colorSpace = { "colorspace", "gray" };
-    
+
     acf.chnsPyramid(Ip, &pyramid.pPyramid, pyramid, true, {}); // compute the pyramid
-    
+
     int i = 0, j = 0, k = 0;
-    for(auto iter = pyramid.data.begin(); iter != pyramid.data.end(); iter++, i++)
+    for (auto iter = pyramid.data.begin(); iter != pyramid.data.end(); iter++, i++)
     {
-        for(auto jter = iter->begin(); jter != iter->end(); jter++, j++)
+        for (auto jter = iter->begin(); jter != iter->end(); jter++, j++)
         {
-            for(auto kter = jter->begin(); kter != jter->end(); kter++, k++)
+            for (auto kter = jter->begin(); kter != jter->end(); kter++, k++)
             {
                 cv::Mat I8uc1;
                 kter->convertTo(I8uc1, CV_8UC1, 255.0);
-                
+
                 // Undo the TRANPOSE for each channel before writing to disk
                 // for visualization in row major format
                 I8uc1 = I8uc1.t();
-                
+
                 std::stringstream ss;
                 ss << base << std::setw(4) << std::setfill('0') << i << "_" << j << "_" << k << ".png";
                 cv::imwrite(ss.str(), I8uc1);

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -10,37 +10,58 @@
 find_package(sugar CONFIG REQUIRED)
 sugar_include(.)
 
+
+### acf_util ###
+add_library(acf_util ${ACF_UTIL_SRCS} ${ACF_UTIL_HDRS})
+target_link_libraries(acf_util PUBLIC spdlog::spdlog ${OpenCV_LIBS})
+
+### acf_shaders ###
+add_library(acf_shaders ${ACF_GPU_SRCS} ${ACF_GPU_HDRS})
+target_link_libraries(acf_shaders PUBLIC spdlog::spdlog ${OpenCV_LIBS})
+
+### acf ###
 if(ACF_BUILD_SHARED_SDK)
   set(acf_lib_type SHARED)
 else()
   set(acf_lib_type STATIC)
 endif()
-
-add_library(acf ${acf_lib_type} ${ACF_SRCS} ${ACF_HDRS} ${ACF_HDRS_PUBLIC})
+  
+add_library(acf ${acf_lib_type}
+  ${ACF_SRCS}
+  ${ACF_HDRS}
+  ${ACF_HDRS_PUBLIC}
+)
 target_link_libraries(acf
   PUBLIC ${ACF_3RDPARTY_PKG_LIBS}
-  PRIVATE ${ACF_3RDPARTY_PKG_LIBS_}
+  PRIVATE ${ACF_3RDPARTY_PKG_LIBS_} acf_util acf_shaders
 )
-target_compile_definitions(acf PUBLIC _USE_MATH_DEFINES)  # define M_PI_2 for Visual Studio
 target_compile_definitions(acf PUBLIC ACF_DO_HALF=1)  # half precision serialization
 if(ACF_SERIALIZE_WITH_CVMATIO)
   target_compile_definitions(acf PUBLIC ACF_SERIALIZE_WITH_CVMATIO=1)
 endif()
-if(ACF_ADD_TO_STRING)
-  target_compile_definitions(acf PUBLIC ACF_ADD_TO_STRING=1)
-endif()
+
+target_include_directories(acf
+  PUBLIC
+  "$<BUILD_INTERFACE:${ACF_ROOT_DIR}/src/lib/>"
+  "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>"
+)
+
+foreach(lib acf_util acf_shaders acf)
+  target_include_directories(${lib} PUBLIC "$<BUILD_INTERFACE:${ACF_ROOT_DIR}/src/lib/>")
+  if(MSVC)
+    target_compile_definitions(${lib} PUBLIC _USE_MATH_DEFINES) # define M_PI_2 for Visual Studio
+    target_compile_definitions(${lib} PUBLIC NOMINMAX=1) # avoid std::{min,max}() conflicts
+  endif()  
+  if(NOT ACF_HAVE_TO_STRING)
+    target_compile_definitions(${lib} PUBLIC ACF_ADD_TO_STRING=1)
+  endif()  
+endforeach()
 
 ### Generate the export header
 include(GenerateExportHeader)
 set(acf_export_dir "${CMAKE_BINARY_DIR}/acf")
 set(acf_export_header "${acf_export_dir}/acf_export.h")
 generate_export_header(acf EXPORT_FILE_NAME "${acf_export_header}")
-
-target_include_directories(acf
-  PUBLIC
-  "$<BUILD_INTERFACE:${ACF_ROOT_DIR}/src/lib/>"
-  "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>"
-  )
 
 string(COMPARE EQUAL "${CMAKE_OSX_SYSROOT}" "iphoneos" is_ios)
 if(NOT is_ios)
@@ -94,7 +115,7 @@ configure_package_config_file(
 #   * header location after install: <prefix>/include/acf/ACF.h
 #   * headers can be included by C++ code `#include <acf/ACF.h>`
 install(
-    TARGETS acf
+    TARGETS acf acf_util acf_shaders
     EXPORT "${targets_export_name}"
     LIBRARY DESTINATION "lib"
     ARCHIVE DESTINATION "lib"

--- a/src/lib/acf/ACF.cpp
+++ b/src/lib/acf/ACF.cpp
@@ -385,7 +385,8 @@ std::ostream& operator<<(std::ostream& os, const Detector::Options::Pyramid::Chn
     os << src.binSize << std::endl;
     os << src.nOrients << std::endl;
     os << src.softBin << std::endl;
-    os << src.useHog;
+    os << src.useHog << std::endl;
+    os << src.clipHog;
     return os;
 }
 
@@ -525,6 +526,7 @@ void Detector::Options::Pyramid::Chns::GradHist::merge(const GradHist& src, int 
     nOrients.merge(src.nOrients, checkExtra);
     softBin.merge(src.softBin, checkExtra);
     useHog.merge(src.useHog, checkExtra);
+    clipHog.merge(src.clipHog, checkExtra);
 }
 
 void Detector::Options::Pyramid::Chns::Custom::merge(const Custom& src, int checkExtra)
@@ -618,5 +620,19 @@ void Detector::Options::merge(const Options& src, int checkExtra)
     pNms.merge(src.pNms, checkExtra);
     pPyramid.merge(src.pPyramid, checkExtra);
 }
+
+template ACF_EXPORT struct acf::Field<int>;
+template ACF_EXPORT struct acf::Field<double>;
+template ACF_EXPORT struct acf::Field<std::string>;
+template ACF_EXPORT struct acf::Field<std::vector<double>>;
+template ACF_EXPORT struct acf::Field<acf::Detector::Options>;
+template ACF_EXPORT struct acf::Field<acf::Detector::Options::Boost::Tree>;
+template ACF_EXPORT struct acf::Field<acf::Detector::Options::Jitter>;
+template ACF_EXPORT struct acf::Field<acf::Detector::Options::Pyramid>;
+template ACF_EXPORT struct acf::Field<acf::Detector::Options::Nms>;
+template ACF_EXPORT struct acf::Field<acf::Detector::Options::Pyramid::Chns>;
+template ACF_EXPORT struct acf::Field<acf::Detector::Options::Pyramid::Chns::Color>;
+template ACF_EXPORT struct acf::Field<acf::Detector::Options::Pyramid::Chns::GradMag>;
+template ACF_EXPORT struct acf::Field<acf::Detector::Options::Pyramid::Chns::GradHist>;
 
 ACF_NAMESPACE_END

--- a/src/lib/acf/ACFField.h
+++ b/src/lib/acf/ACFField.h
@@ -24,8 +24,9 @@ template <typename T>
 struct ACF_EXPORT Field
 {
     Field()
+        : has(false)
     {
-        has = false;
+
     }
     Field(const T& t)
         : value(t)
@@ -34,15 +35,13 @@ struct ACF_EXPORT Field
     }
     Field(const std::string& name, const T& value, bool)
         : value(value)
-        , isLeaf(true)
         , name(name)
         , has(true)
+        , isLeaf(true)
     {
     }
 
-    ~Field()
-    {
-    }
+    ~Field() = default;
 
     Field<T>& operator=(const std::pair<std::string, T>& src)
     {

--- a/src/lib/acf/ACFIOArchiveCereal.cpp
+++ b/src/lib/acf/ACFIOArchiveCereal.cpp
@@ -18,28 +18,28 @@ ACF_NAMESPACE_BEGIN
 // ##################################################################
 
 typedef cereal::PortableBinaryOutputArchive OArchive;
-template void Detector::serialize<OArchive>(OArchive& ar, const std::uint32_t);
-template void Detector::Options::serialize<OArchive>(OArchive& ar, const std::uint32_t);
-template void Detector::Options::Boost::serialize<OArchive>(OArchive& ar, const std::uint32_t);
-template void Detector::Options::Boost::Tree::serialize<OArchive>(OArchive& ar, const std::uint32_t);
-template void Detector::Options::Jitter::serialize<OArchive>(OArchive& ar, const std::uint32_t);
-template void Detector::Options::Pyramid::serialize<OArchive>(OArchive& ar, const std::uint32_t);
-template void Detector::Options::Nms::serialize<OArchive>(OArchive& ar, const std::uint32_t);
-template void Detector::Options::Pyramid::Chns::serialize<OArchive>(OArchive& ar, const std::uint32_t);
-template void Detector::Options::Pyramid::Chns::Color::serialize<OArchive>(OArchive& ar, const std::uint32_t);
-template void Detector::Options::Pyramid::Chns::GradMag::serialize<OArchive>(OArchive& ar, const std::uint32_t);
-template void Detector::Options::Pyramid::Chns::GradHist::serialize<OArchive>(OArchive& ar, const std::uint32_t);
+template ACF_EXPORT void Detector::serialize<OArchive>(OArchive& ar, const std::uint32_t);
+template ACF_EXPORT void Detector::Options::serialize<OArchive>(OArchive& ar, const std::uint32_t);
+template ACF_EXPORT void Detector::Options::Boost::serialize<OArchive>(OArchive& ar, const std::uint32_t);
+template ACF_EXPORT void Detector::Options::Boost::Tree::serialize<OArchive>(OArchive& ar, const std::uint32_t);
+template ACF_EXPORT void Detector::Options::Jitter::serialize<OArchive>(OArchive& ar, const std::uint32_t);
+template ACF_EXPORT void Detector::Options::Pyramid::serialize<OArchive>(OArchive& ar, const std::uint32_t);
+template ACF_EXPORT void Detector::Options::Nms::serialize<OArchive>(OArchive& ar, const std::uint32_t);
+template ACF_EXPORT void Detector::Options::Pyramid::Chns::serialize<OArchive>(OArchive& ar, const std::uint32_t);
+template ACF_EXPORT void Detector::Options::Pyramid::Chns::Color::serialize<OArchive>(OArchive& ar, const std::uint32_t);
+template ACF_EXPORT void Detector::Options::Pyramid::Chns::GradMag::serialize<OArchive>(OArchive& ar, const std::uint32_t);
+template ACF_EXPORT void Detector::Options::Pyramid::Chns::GradHist::serialize<OArchive>(OArchive& ar, const std::uint32_t);
 
 typedef cereal::PortableBinaryInputArchive IArchive;
-template void Detector::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
-template void Detector::Options::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
-template void Detector::Options::Boost::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
-template void Detector::Options::Boost::Tree::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
-template void Detector::Options::Jitter::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
-template void Detector::Options::Pyramid::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
-template void Detector::Options::Nms::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
-template void Detector::Options::Pyramid::Chns::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
-template void Detector::Options::Pyramid::Chns::Color::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
-template void Detector::Options::Pyramid::Chns::GradMag::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
-template void Detector::Options::Pyramid::Chns::GradHist::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
+template ACF_EXPORT void Detector::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
+template ACF_EXPORT void Detector::Options::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
+template ACF_EXPORT void Detector::Options::Boost::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
+template ACF_EXPORT void Detector::Options::Boost::Tree::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
+template ACF_EXPORT void Detector::Options::Jitter::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
+template ACF_EXPORT void Detector::Options::Pyramid::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
+template ACF_EXPORT void Detector::Options::Nms::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
+template ACF_EXPORT void Detector::Options::Pyramid::Chns::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
+template ACF_EXPORT void Detector::Options::Pyramid::Chns::Color::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
+template ACF_EXPORT void Detector::Options::Pyramid::Chns::GradMag::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
+template ACF_EXPORT void Detector::Options::Pyramid::Chns::GradHist::serialize<IArchive>(IArchive& ar, const std::uint32_t version);
 ACF_NAMESPACE_END

--- a/src/lib/acf/GPUACF.h
+++ b/src/lib/acf/GPUACF.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <array>
+#include <functional>
 
 // clang-format off
 namespace spdlog { class logger; }
@@ -47,6 +48,8 @@ public:
     ACF(void* glContext, const Size2d& size, const SizeVec& scales, FeatureKind kind, int grayWidth = 0, int shrink = 4);
     ~ACF();
 
+    // Platform specify OpenGL bindings (e.g., windows DLL + glewInit())
+    static void updateGL();
     static void tryEnablePlatformOptimizations();
 
     void setUsePBO(bool flag);

--- a/src/lib/acf/chnsPyramid.cpp
+++ b/src/lib/acf/chnsPyramid.cpp
@@ -253,7 +253,7 @@ int Detector::chnsPyramid
     {
         rgbConvert(pI, I, cs, true, m_isLuv);
     }
-    
+
     pChns.pColor->colorSpace = std::string("orig");
 
     auto& info = pyramid.info;
@@ -337,7 +337,7 @@ int Detector::chnsPyramid
         std::vector<int> is;
         for (int i = (1 + nOctUp * nPerOct); i <= nScales; i += (nApprox + 1))
         {
-            is.push_back(i-1);
+            is.push_back(i - 1);
         }
 
         CV_Assert(is.size() >= 2);
@@ -367,17 +367,17 @@ int Detector::chnsPyramid
         }
     }
 
-    // The per scale/type operations are easily parallelized, but with a parallel_for approach 
+    // The per scale/type operations are easily parallelized, but with a parallel_for approach
     // using simple uniform slicing will tend to starve some threads due to the nature of the
     // pyramid layout.  Randomizing the scale indices should do better.  More optimal strategies
     // may exist with further testing (work stealing, etc).
     const auto scalesIndex = util::create_random_indices(nScales);
-    
+
     auto isAIndex = isA;
     std::random_shuffle(isAIndex.begin(), isAIndex.end());
-    
-    cv::parallel_for_({ 0, int(isAIndex.size()) }, [&](const cv::Range &r) {
-        for(int k = r.start; k < r.end; k++)
+
+    cv::parallel_for_({ 0, int(isAIndex.size()) }, [&](const cv::Range& r) {
+        for (int k = r.start; k < r.end; k++)
         {
             const int i = isAIndex[k];
             const int iR = isN[i - 1];
@@ -390,9 +390,8 @@ int Detector::chnsPyramid
         }
     });
 
-
-    cv::parallel_for_({ 0, int(scales.size()) }, [&](const cv::Range &r) {
-        for(int i = r.start; i < r.end; i++)
+    cv::parallel_for_({ 0, int(scales.size()) }, [&](const cv::Range& r) {
+        for (int i = r.start; i < r.end; i++)
         {
             for (int j = 0; j < nTypes; j++)
             {
@@ -404,14 +403,14 @@ int Detector::chnsPyramid
     // TODO: test imPad
     if (pad.width || pad.height)
     {
-        cv::parallel_for_({ 0, int(scales.size()) }, [&](const cv::Range &r) {
+        cv::parallel_for_({ 0, int(scales.size()) }, [&](const cv::Range& r) {
             for (int i = r.start; i < r.end; i++)
             {
                 for (int j = 0; j < nTypes; j++)
                 {
                     int y = pad.height / shrink;
                     int x = pad.width / shrink;
-                    auto &I = data[scalesIndex[i]][j];
+                    auto& I = data[scalesIndex[i]][j];
                     copyMakeBorder(I, I, y, y, x, x, cv::BORDER_REFLECT);
                 }
             }

--- a/src/lib/acf/draw.h
+++ b/src/lib/acf/draw.h
@@ -17,7 +17,7 @@
 
 ACF_NAMESPACE_BEGIN
 
-cv::Mat draw(acf::Detector::Pyramid& pyramid);
+cv::Mat ACF_EXPORT draw(acf::Detector::Pyramid& pyramid);
 
 ACF_NAMESPACE_END
 

--- a/src/lib/acf/gpu/multipass/triangle_opt_pass.cpp
+++ b/src/lib/acf/gpu/multipass/triangle_opt_pass.cpp
@@ -1,0 +1,233 @@
+/*! -*-c++-*-
+  @file   triangle_opt_pass.cpp
+  @author David Hirvonen (C++ implementation)
+  @brief Definition of a 1D optimized ogles_gpgpu triangle filter shader.
+
+  This separable filter makes use of OpengL HW texel interpolation to replace two adjacent 
+  integer offset kernel coefficients with a single coefficient for a single (interpolated)
+  texel lookup.  The code is adapted from the following:
+
+  https://github.com/BradLarson/GPUImage/blob/master/framework/Source/GPUImageSingleComponentGaussianBlurFilter.m#L5-L186
+
+  Which is released under compatible 3-clause BSD license:
+
+  https://github.com/BradLarson/GPUImage/blob/master/License.txt
+
+  \copyright Copyright 2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#include <acf/gpu/multipass/triangle_opt_pass.h>
+
+#include <ogles_gpgpu/common/common_includes.h>
+
+#include <cmath>
+
+using namespace ogles_gpgpu;
+
+static void getOptimizedTriangle(int blurRadius, std::vector<GLfloat>& weights, std::vector<GLfloat>& offsets)
+{
+    std::vector<GLfloat> standardTriangleWeights(blurRadius + 1);
+    const GLfloat sumOfWeights = ((blurRadius + 1) * (blurRadius + 1));
+    const GLfloat norm = 1.0f / sumOfWeights;
+    const int maxCoeff = (blurRadius + 1);
+
+    for (int currentTriangleWeightIndex = 0; currentTriangleWeightIndex < (blurRadius + 1); currentTriangleWeightIndex++)
+    {
+        standardTriangleWeights[currentTriangleWeightIndex] = norm * GLfloat(maxCoeff - currentTriangleWeightIndex);
+    }
+
+    // From these weights we calculate the offsets to read interpolated values from
+    const int numberOfOptimizedOffsets = std::min(blurRadius / 2 + (blurRadius % 2), 7);
+
+    std::vector<GLfloat> optimizedTriangleOffsets(numberOfOptimizedOffsets);
+    for (int currentOptimizedOffset = 0; currentOptimizedOffset < numberOfOptimizedOffsets; currentOptimizedOffset++)
+    {
+        const int firstIndex = currentOptimizedOffset * 2 + 1;
+        const int secondIndex = currentOptimizedOffset * 2 + 2;
+        const GLfloat firstWeight = standardTriangleWeights[firstIndex];
+        const GLfloat secondWeight = standardTriangleWeights[secondIndex];
+        const GLfloat optimizedWeight = firstWeight + secondWeight;
+        const GLfloat optimizedOffset = (firstWeight * firstIndex + secondWeight * secondIndex) / optimizedWeight;
+        optimizedTriangleOffsets[currentOptimizedOffset] = optimizedOffset;
+    }
+
+    weights = standardTriangleWeights;
+    offsets = optimizedTriangleOffsets;
+}
+
+static std::string fragmentShaderForOptimizedTriangle(int blurRadius, bool doNorm = false, int pass = 1, float normConst = 0.005f)
+{
+    std::vector<GLfloat> standardTriangleWeights;
+    std::vector<GLfloat> optimizedTriangleOffsets;
+    getOptimizedTriangle(blurRadius, standardTriangleWeights, optimizedTriangleOffsets);
+
+    // From these weights we calculate the offsets to read interpolated values from
+    int numberOfOptimizedOffsets = std::min(blurRadius / 2 + (blurRadius % 2), 7);
+    int trueNumberOfOptimizedOffsets = blurRadius / 2 + (blurRadius % 2);
+
+    std::stringstream ss;
+#if defined(OGLES_GPGPU_OPENGLES)
+    ss << "precision highp float;\n";
+    ss << "\n";
+#endif
+    ss << "uniform sampler2D inputImageTexture;\n";
+    ss << "uniform float texelWidthOffset;\n";
+    ss << "uniform float texelHeightOffset;\n\n";
+    ss << "varying vec2 blurCoordinates[" << (1 + (numberOfOptimizedOffsets * 2)) << "];\n\n";
+    ss << "void main()\n";
+    ss << "{\n";
+    ss << "   vec4 sum = vec4(0.0);\n";
+    ss << "   vec4 center = texture2D(inputImageTexture, blurCoordinates[0]);\n";
+    ss << "   sum += center * " << standardTriangleWeights[0] << ";\n";
+
+    for (int currentBlurCoordinateIndex = 0; currentBlurCoordinateIndex < numberOfOptimizedOffsets; currentBlurCoordinateIndex++)
+    {
+        GLfloat firstWeight = standardTriangleWeights[currentBlurCoordinateIndex * 2 + 1];
+        GLfloat secondWeight = standardTriangleWeights[currentBlurCoordinateIndex * 2 + 2];
+        GLfloat optimizedWeight = firstWeight + secondWeight;
+        int index1 = (unsigned long)((currentBlurCoordinateIndex * 2) + 1);
+        int index2 = (unsigned long)((currentBlurCoordinateIndex * 2) + 2);
+        ss << "   sum += texture2D(inputImageTexture, blurCoordinates[" << index1 << "]) * " << optimizedWeight << ";\n";
+        ss << "   sum += texture2D(inputImageTexture, blurCoordinates[" << index2 << "]) * " << optimizedWeight << ";\n";
+    }
+
+    // If the number of required samples exceeds the amount we can pass in via varyings, we have to do dependent texture reads in the fragment shader
+    if (trueNumberOfOptimizedOffsets > numberOfOptimizedOffsets)
+    {
+        ss << "   vec2 singleStepOffset = vec2(texelWidthOffset, texelHeightOffset);\n";
+        for (int currentOverlowTextureRead = numberOfOptimizedOffsets; currentOverlowTextureRead < trueNumberOfOptimizedOffsets; currentOverlowTextureRead++)
+        {
+            GLfloat firstWeight = standardTriangleWeights[currentOverlowTextureRead * 2 + 1];
+            GLfloat secondWeight = standardTriangleWeights[currentOverlowTextureRead * 2 + 2];
+
+            GLfloat optimizedWeight = firstWeight + secondWeight;
+            GLfloat optimizedOffset = (firstWeight * (currentOverlowTextureRead * 2 + 1) + secondWeight * (currentOverlowTextureRead * 2 + 2)) / optimizedWeight;
+
+            ss << "   sum += texture2D(inputImageTexture, blurCoordinates[0] + singleStepOffset * " << optimizedOffset << ") * " << optimizedWeight << ";\n";
+            ss << "   sum += texture2D(inputImageTexture, blurCoordinates[0] - singleStepOffset * " << optimizedOffset << ") * " << optimizedWeight << ";\n";
+        }
+    }
+
+    if (doNorm)
+    {
+        if (pass == 1)
+        {
+            ss << "   gl_FragColor = vec4(center.rgb, sum.r);\n";
+        }
+        else
+        {
+            ss << "   gl_FragColor = vec4( center.r/(sum.a + " << std::fixed << normConst << "), center.gb, 1.0);\n";
+        }
+    }
+    else
+    {
+        ss << "   gl_FragColor = sum;\n";
+    }
+
+    ss << "}\n";
+
+    return ss.str();
+}
+
+std::string vertexShaderForOptimizedTriangle(int blurRadius)
+{
+    std::vector<GLfloat> standardTriangleWeights;
+    std::vector<GLfloat> optimizedTriangleOffsets;
+    getOptimizedTriangle(blurRadius, standardTriangleWeights, optimizedTriangleOffsets);
+
+    int numberOfOptimizedOffsets = optimizedTriangleOffsets.size();
+
+    std::stringstream ss;
+    ss << "attribute vec4 position;\n";
+    ss << "attribute vec4 inputTextureCoordinate;\n";
+    ss << "uniform float texelWidthOffset;\n";
+    ss << "uniform float texelHeightOffset;\n\n";
+    ss << "varying vec2 blurCoordinates[" << (unsigned long)(1 + (numberOfOptimizedOffsets * 2)) << "];\n\n";
+    ss << "void main()\n";
+    ss << "{\n";
+    ss << "   gl_Position = position;\n";
+    ss << "   vec2 singleStepOffset = vec2(texelWidthOffset, texelHeightOffset);\n";
+    ss << "   blurCoordinates[0] = inputTextureCoordinate.xy;\n";
+    for (int currentOptimizedOffset = 0; currentOptimizedOffset < numberOfOptimizedOffsets; currentOptimizedOffset++)
+    {
+        int x1 = (unsigned long)((currentOptimizedOffset * 2) + 1);
+        int x2 = (unsigned long)((currentOptimizedOffset * 2) + 2);
+        const auto& optOffset = optimizedTriangleOffsets[currentOptimizedOffset];
+
+        ss << "   blurCoordinates[" << x1 << "] = inputTextureCoordinate.xy + singleStepOffset * " << optOffset << ";\n";
+        ss << "   blurCoordinates[" << x2 << "] = inputTextureCoordinate.xy - singleStepOffset * " << optOffset << ";\n";
+    }
+    ss << "}\n";
+
+    return ss.str();
+}
+
+// Calculate the number of pixels to sample from by setting a bottom limit for the contribution of the outermost pixel
+// The normalized outermost pixel should not be below:
+//
+//    float minimumWeightToFindEdgeOfSamplingArea = 1.0 / 256.0;
+//
+// We know the unnormalized edge coefficient will always be 1.0.
+// The sum of coefficients will always be: (blurRadius + 1) * (blurRadius + 1)
+// So we need to make sure: ((blurRadius + 1) * (blurRadius + 1)) < 256.0
+// Solve:
+//    x*x + 2x + 2 < 256
+//    x < sqrt(255) - 1
+//    x < 14.9
+//
+// The largest kernel radius is 14.9, or 14
+
+void TriangleOptProcPass::setRadius(int newValue)
+{
+    if (newValue != _blurRadiusInPixels)
+    {
+        const int blurRadius = newValue + (newValue % 2); // enforce even blur (as with GPUImage)
+        _blurRadiusInPixels = std::min(blurRadius, 14);
+        vshaderTriangleSrc = vertexShaderForOptimizedTriangle(_blurRadiusInPixels);
+        fshaderTriangleSrc = fragmentShaderForOptimizedTriangle(_blurRadiusInPixels, doNorm, renderPass, normConst);
+    }
+}
+
+void TriangleOptProcPass::filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target)
+{
+    // create shader object
+    ProcBase::createShader(vShaderSrc, fShaderSrc, target);
+
+    // get shader params
+    shParamAPos = shader->getParam(ATTR, "position");
+    shParamATexCoord = shader->getParam(ATTR, "inputTextureCoordinate");
+    Tools::checkGLErr(getProcName(), "filterShaderSetup");
+}
+
+void TriangleOptProcPass::setUniforms()
+{
+    FilterProcBase::setUniforms();
+
+    glUniform1f(shParamUTexelWidthOffset, (renderPass == 1) * pxDx);
+    glUniform1f(shParamUTexelHeightOffset, (renderPass == 2) * pxDy);
+}
+
+void TriangleOptProcPass::getUniforms()
+{
+    FilterProcBase::getUniforms();
+
+    // calculate pixel delta values
+    pxDx = 1.0f / (float)outFrameW;
+    pxDy = 1.0f / (float)outFrameH;
+
+    shParamUInputTex = shader->getParam(UNIF, "inputImageTexture");
+    shParamUTexelWidthOffset = shader->getParam(UNIF, "texelWidthOffset");
+    shParamUTexelHeightOffset = shader->getParam(UNIF, "texelHeightOffset");
+}
+
+const char* TriangleOptProcPass::getFragmentShaderSource()
+{
+    return fshaderTriangleSrc.c_str();
+}
+
+const char* TriangleOptProcPass::getVertexShaderSource()
+{
+    return vshaderTriangleSrc.c_str();
+}

--- a/src/lib/acf/gpu/multipass/triangle_opt_pass.h
+++ b/src/lib/acf/gpu/multipass/triangle_opt_pass.h
@@ -1,0 +1,86 @@
+/*! -*-c++-*-
+  @file   triangle_opt_pass.h
+  @author David Hirvonen (C++ implementation)
+  @brief Declaration of an optimized 2D separable ogles_gpgpu triangle filter shader.
+
+  This separable filter makes use of OpengL HW texel interpolation to replace two adjacent 
+  integer offset kernel coefficients with a single coefficient for a single (interpolated)
+  texel lookup.  The code is adapted from:
+
+  https://github.com/BradLarson/GPUImage/blob/master/framework/Source/GPUImageSingleComponentGaussianBlurFilter.m#L5-L186
+
+  \copyright Copyright 2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+/**
+ * GPGPU gaussian smoothing processor.
+ */
+#ifndef __acf_gpu_multipass_triangle_pass_h__
+#define __acf_gpu_multipass_triangle_pass_h__
+
+#include <acf/acf_common.h>
+
+#include <ogles_gpgpu/common/common_includes.h>
+#include <ogles_gpgpu/common/proc/base/filterprocbase.h>
+
+BEGIN_OGLES_GPGPU
+
+/**
+ * This filter applies gaussian smoothing to an input image.
+ */
+class TriangleOptProcPass : public FilterProcBase
+{
+public:
+    /**
+     * Construct as render pass <pass> (1 or 2).
+     */
+    TriangleOptProcPass(int pass, int radius, bool doNorm = false, float normConst = 0.005f)
+        : FilterProcBase()
+        , doNorm(doNorm)
+        , renderPass(pass)
+        , pxDx(0.0f)
+        , pxDy(0.0f)
+        , normConst(normConst)
+    {
+        setRadius(radius);
+        assert(renderPass == 1 || renderPass == 2);
+    }
+
+    void setRadius(int newValue);
+
+    /**
+     * Return the processors name.
+     */
+    virtual const char* getProcName()
+    {
+        return "TriangleOptProcPass";
+    }
+
+    virtual void filterShaderSetup(const char* vShaderSrc, const char* fShaderSrc, GLenum target);
+    virtual void setUniforms();
+    virtual void getUniforms();
+    virtual const char* getFragmentShaderSource();
+    virtual const char* getVertexShaderSource();
+
+private:
+    bool doNorm = false;
+    int renderPass; // render pass number. must be 1 or 2
+
+    float pxDx; // pixel delta value for texture access
+    float pxDy; // pixel delta value for texture access
+
+    float normConst = 0.005;
+
+    int _blurRadiusInPixels = 0.0; // start 0 (uninitialized)
+
+    GLint shParamUTexelWidthOffset;
+    GLint shParamUTexelHeightOffset;
+
+    std::string vshaderTriangleSrc;
+    std::string fshaderTriangleSrc;
+};
+
+END_OGLES_GPGPU
+#endif

--- a/src/lib/acf/gpu/triangle_opt.cpp
+++ b/src/lib/acf/gpu/triangle_opt.cpp
@@ -1,0 +1,26 @@
+/*! -*-c++-*-
+  @file   triangle.cpp
+  @author David Hirvonen (C++ implementation)
+  @brief Implementation of an optimized 2D separable ogles_gpgpu triangle filter shader.
+
+  The filter uses built in OpengL texel interpolation to reduce the kernel coefficient.
+
+  \copyright Copyright 2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+#include <acf/gpu/triangle_opt.h>
+
+BEGIN_OGLES_GPGPU
+
+TriangleOptProc::TriangleOptProc(int radius, bool doNorm, float normConst)
+{
+    TriangleOptProcPass* triPass1 = new TriangleOptProcPass(1, radius, doNorm);
+    TriangleOptProcPass* triPass2 = new TriangleOptProcPass(2, radius, doNorm, normConst);
+
+    procPasses.push_back(triPass1);
+    procPasses.push_back(triPass2);
+}
+
+END_OGLES_GPGPU

--- a/src/lib/acf/gpu/triangle_opt.h
+++ b/src/lib/acf/gpu/triangle_opt.h
@@ -1,0 +1,46 @@
+/*! -*-c++-*-
+  @file   triangle_opt.h
+  @author David Hirvonen (C++ implementation)
+  @brief Declaration of an optimized 2D separable ogles_gpgpu triangle filter shader.
+
+  This separable filter makes use of OpengL HW texel interpolation to replace two adjacent 
+  integer offset kernel coefficients with a single coefficient for a single (interpolated)
+  texel lookup.  The code is adapted from:
+
+  https://github.com/BradLarson/GPUImage/blob/master/framework/Source/GPUImageSingleComponentGaussianBlurFilter.m#L5-L186
+
+  \copyright Copyright 2018 Elucideye, Inc. All rights reserved.
+  \license{This project is released under the 3 Clause BSD License.}
+
+*/
+
+/**
+ * GPGPU gaussian smoothing processor (two-pass).
+ */
+#ifndef __acf_gpu_triangle_opt_h__
+#define __acf_gpu_triangle_opt_h__
+
+#include <acf/acf_common.h>
+#include <acf/gpu/multipass/triangle_opt_pass.h>
+
+#include <ogles_gpgpu/common/common_includes.h>
+#include <ogles_gpgpu/common/proc/base/multipassproc.h>
+
+BEGIN_OGLES_GPGPU
+
+class TriangleOptProc : public MultiPassProc
+{
+public:
+    TriangleOptProc(int radius, bool doNorm = false, float normConst = 0.005f);
+    /**
+     * Return the processors name.
+     */
+    virtual const char* getProcName()
+    {
+        return "TriangleOptProc";
+    }
+};
+
+END_OGLES_GPGPU
+
+#endif // __acf_gpu_triangle_opt_h__

--- a/src/lib/acf/sugar.cmake
+++ b/src/lib/acf/sugar.cmake
@@ -60,22 +60,27 @@ sugar_files(ACF_HDRS_PUBLIC
   )
 
 if(ACF_BUILD_OGLES_GPGPU)
-  sugar_files(ACF_HDRS_PUBLIC 
-    GPUACF.h
-    )
-  sugar_files(ACF_HDRS
+  # Public GPUACF classes added to the main library
+  sugar_files(ACF_HDRS_PUBLIC GPUACF.h)
+  sugar_files(ACF_SRCS GPUACF.cpp)
+
+  # All other shaders to in the acf_shaders utility lib for reuse
+  sugar_files(ACF_GPU_HDRS
     gpu/gradhist.h
     gpu/multipass/triangle_pass.h
+    gpu/multipass/triangle_opt_pass.h
     gpu/swizzle2.h
     gpu/triangle.h
+    gpu/triangle_opt.h    
     gpu/binomial.h
-    )
-  sugar_files(ACF_SRCS
-    GPUACF.cpp
+  )
+  sugar_files(ACF_GPU_SRCS
     gpu/gradhist.cpp
     gpu/multipass/triangle_pass.cpp
+    gpu/multipass/triangle_opt_pass.cpp
     gpu/swizzle2.cpp
     gpu/triangle.cpp
+    gpu/triangle_opt.cpp
     gpu/binomial.cpp
-    )
+  )
 endif()

--- a/src/lib/acf/ut/CMakeLists.txt
+++ b/src/lib/acf/ut/CMakeLists.txt
@@ -8,7 +8,7 @@ set(acf_ut_srcs test-acf.cpp)
 
 add_executable(${test_app} ${acf_ut_srcs})
 set_property(TARGET ${test_app} PROPERTY FOLDER "app/tests")
-target_link_libraries(${test_app} PUBLIC acf GTest::gtest ${OpenCV_LIBS})
+target_link_libraries(${test_app} PUBLIC acf acf_util acf_shaders GTest::gtest ${OpenCV_LIBS})
 
 if (ACF_BUILD_OGLES_GPGPU AND TARGET aglet::aglet)
   target_link_libraries(${test_app} PUBLIC aglet::aglet)
@@ -26,3 +26,12 @@ gauze_add_test(
   "$<GAUZE_RESOURCE_FILE:${ACF_CALTECH_DETECTOR_MAT}>"
   "$<GAUZE_RESOURCE_FILE:${ACF_PEDESTRIAN_IMAGE}>"
 )
+
+if(WIN32 OR CYGWIN)
+  set_property(
+    TEST ${test_name}
+    PROPERTY
+    ENVIRONMENT
+    "PATH=$<TARGET_FILE_DIR:acf>;$ENV{PATH}"
+   )
+endif()

--- a/src/lib/util/sugar.cmake
+++ b/src/lib/util/sugar.cmake
@@ -6,7 +6,7 @@ endif()
 
 include(sugar_files)
 
-sugar_files(ACF_HDRS
+sugar_files(ACF_UTIL_HDRS
   IndentingOStreamBuffer.h
   LazyParallelResource.h
   Line.h
@@ -23,7 +23,7 @@ sugar_files(ACF_HDRS
   timing.h
   )
 
-sugar_files(ACF_SRCS
+sugar_files(ACF_UTIL_SRCS
   Logger.cpp
   arithmetic.cpp
   convert.cpp


### PR DESCRIPTION
This PR contains a separable optimized `TriangleOptProc` that address a few open issues (efficiency/speed and exceeding some platform`varying` array limits).  It also contains some lib/cmake refactoring to accommodate `SHARED` lib builds and some Windows specific fixes.  The CI setup files appveyor.yml and .travis.yml are also updated to use the cleaner/simpler templates from ingenue/hunter testing as well as the drishti/bin/hunter_env.{cmd, sh} and build scripts.

### add optimized/separate triangle filter

* add separable optimized triangle filter `TriangleOptProc`  +  `TriangleOptProcPass`  for compatibility with acf filtering based on
`GPUImageSingleComponentGaussianBlurFilter.m`
  + https://github.com/elucideye/acf/issues/48
  + https://github.com/elucideye/acf/issues/64
* add GTest for TriangleOptProc
* minor gpu + acf tuning (this will always be an approximation of CPU code)
* run clang-format
* update appveyor/travis configs to match drishti repo -- this provide a much simpler clang linux setup without the travis permission symbolic link workarounds
* be sure to wrap all OpenGL sections in `#if defined(ACF_DO_GPU)`

This separable filter makes use of OpenGL HW texel interpolation to replace two adjacent integer offset kernel coefficients with a single coefficient for a single (interpolated) texel lookup.  The code is adapted from the following:

https://github.com/BradLarson/GPUImage/blob/master/framework/Source/GPUImageSingleComponentGaussianBlurFilter.m#L5-L186

Which is released under compatible 3-clause BSD license:

https://github.com/BradLarson/GPUImage/blob/master/License.txt

### ACF lib/cmake refactoring to support SHARED builds

* create `acf_util` from src/lib/util for internal reuse — this is allows creating a SHARED acf lib without exporting this local utils
* create `acf_shader` from src/lib/acf/gpu for internal use -- if CMake OBJECT libraries worked portably, this would probably be an OBJECT library.
* link tests and local apps with STATIC `acf_util` and `acf_shader` (optional if using GPGPU)
* update `RPATH` handling in `acf` top CMakeLists.txt for relocatable install tree
* simplify: use `ACF_HAVE_TO_STRING` result from try_compile testing directly
* add `ACF_EXPORT` for explicit template declarations in ACFIOArchiveCereal.cpp
* reduce repetition value for acf-pipeline in CI test so test finishes in reasonable amount of time
* ACFField: use `default` destructor and fix constructor initialization order

### Windows

* set `PATH` for gauze tests on MSVC platforms
* export `acf::Field<...>` templates
* export `draw()` for pyramid visualization
* add update `ACF::updateGL()` API call to support platform specific OpenGL bindings from within the `SHARED` lib (e.g., windows DLL + glewInit())
* call `updateGL()` in apps/tests: `acf-detector` (GLDetector); `acf-pipeline`, `test-acf`
