### PR TITLE
reorder ACF_EXPORT <-> struct

### DIFF
--- a/src/lib/acf/ACF.cpp
+++ b/src/lib/acf/ACF.cpp
@@ -621,18 +621,18 @@ void Detector::Options::merge(const Options& src, int checkExtra)
     pPyramid.merge(src.pPyramid, checkExtra);
 }
 
-template ACF_EXPORT struct acf::Field<int>;
-template ACF_EXPORT struct acf::Field<double>;
-template ACF_EXPORT struct acf::Field<std::string>;
-template ACF_EXPORT struct acf::Field<std::vector<double>>;
-template ACF_EXPORT struct acf::Field<acf::Detector::Options>;
-template ACF_EXPORT struct acf::Field<acf::Detector::Options::Boost::Tree>;
-template ACF_EXPORT struct acf::Field<acf::Detector::Options::Jitter>;
-template ACF_EXPORT struct acf::Field<acf::Detector::Options::Pyramid>;
-template ACF_EXPORT struct acf::Field<acf::Detector::Options::Nms>;
-template ACF_EXPORT struct acf::Field<acf::Detector::Options::Pyramid::Chns>;
-template ACF_EXPORT struct acf::Field<acf::Detector::Options::Pyramid::Chns::Color>;
-template ACF_EXPORT struct acf::Field<acf::Detector::Options::Pyramid::Chns::GradMag>;
-template ACF_EXPORT struct acf::Field<acf::Detector::Options::Pyramid::Chns::GradHist>;
+template struct ACF_EXPORT acf::Field<int>;
+template struct ACF_EXPORT acf::Field<double>;
+template struct ACF_EXPORT acf::Field<std::string>;
+template struct ACF_EXPORT acf::Field<std::vector<double>>;
+template struct ACF_EXPORT acf::Field<acf::Detector::Options>;
+template struct ACF_EXPORT acf::Field<acf::Detector::Options::Boost::Tree>;
+template struct ACF_EXPORT acf::Field<acf::Detector::Options::Jitter>;
+template struct ACF_EXPORT acf::Field<acf::Detector::Options::Pyramid>;
+template struct ACF_EXPORT acf::Field<acf::Detector::Options::Nms>;
+template struct ACF_EXPORT acf::Field<acf::Detector::Options::Pyramid::Chns>;
+template struct ACF_EXPORT acf::Field<acf::Detector::Options::Pyramid::Chns::Color>;
+template struct ACF_EXPORT acf::Field<acf::Detector::Options::Pyramid::Chns::GradMag>;
+template struct ACF_EXPORT acf::Field<acf::Detector::Options::Pyramid::Chns::GradHist>;
 
 ACF_NAMESPACE_END


### PR DESCRIPTION
WRONG:
```
template ACF_EXPORT struct acf::Field<int>;
```
RIGHT:
```
template struct ACF_EXPORT acf::Field<int>;
```