### PR TITLE
featch pretrained eye detectors (grayscale + color)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,3 +234,22 @@ endif()
 ##############
 
 add_subdirectory(src)
+
+
+set(acf_asset_release_url "https://github.com/elucideye/acf/releases/download/v0.0.0")
+
+hunter_private_data(
+  URL "${acf_asset_release_url}/acf_unsplash_60x40_eye_any_color_d4.cpb"
+  SHA1 "063605f07fde62322003690a1bc8d6323025f088"
+  FILE "acf_unsplash_60x40_eye_any_color_d4.cpb"
+  LOCATION ACF_64x40_EYE_ANY_COLOR_D4
+)
+
+hunter_private_data(
+  URL "${acf_asset_release_url}/acf_unsplash_60x40_eye_any_gray_d4.cpb"
+  SHA1 "66a9ed85cc46c1ef193c27e403aae9679114e743"
+  FILE "acf_unsplash_60x40_eye_any_gray_d4.cpb"
+  LOCATION ACF_64x40_EYE_ANY_GRAY_D4
+)
+
+install(FILES ${ACF_64x40_EYE_ANY_GRAY_D4} ${ACF_64x40_EYE_ANY_COLOR_D4} DESTINATION share)

--- a/src/app/acf/acf.cpp
+++ b/src/app/acf/acf.cpp
@@ -172,6 +172,7 @@ int gauze_main(int argc, char** argv)
     bool doRandom = false;
     double cascCal = 0.0;
     int minWidth = -1; // minimum object width
+    float overlap = -1.f;
     //int maxWidth = -1; /* maximum object width TODO */
 
     cxxopts::Options options("acf-detect", "Command line interface for ACF object detection (see Piotr's toolbox)");
@@ -194,6 +195,7 @@ int gauze_main(int argc, char** argv)
         ("g,gpu", "Use gpu pyramid processing", cxxopts::value<bool>(doGpu))
         ("pyramids", "Dump pyramids", cxxopts::value<bool>(doPyramids))
         ("random", "Random frames", cxxopts::value<bool>(doRandom))
+        ("overlap", "NMS overlap", cxxopts::value<float>(overlap))
         ("h,help", "Print help message");
     // clang-format on
 
@@ -286,6 +288,15 @@ int gauze_main(int argc, char** argv)
                 dflt.cascThr = { "cascThr", -1.0 };
                 dflt.cascCal = { "cascCal", cascCal };
                 acf->acfModify(dflt);
+            }
+            
+            if (cli.count("overlap"))
+            {
+                if (overlap <= 0.f || overlap > 1.0)
+                {
+                    throw std::runtime_error("Invalid overlap specified in " + std::to_string(overlap));
+                }
+                acf->opts.pNms->overlap = overlap;
             }
         }
         else


### PR DESCRIPTION
* fetch and install pretrained eye detectors in install/<toolchain>/share
* add acf-detect `—overlap=<value>` option to set overlap term for NMS